### PR TITLE
Increasing maxRequestLength to permit large commits

### DIFF
--- a/Bonobo.Git.Server/Bonobo.Git.Server/web.config
+++ b/Bonobo.Git.Server/Bonobo.Git.Server/web.config
@@ -23,7 +23,7 @@
     </DbProviderFactories>
   </system.data>
   <system.web>
-    <httpRuntime maxRequestLength="102400" />
+    <httpRuntime maxRequestLength="2147483647" />
     <compilation debug="true" targetFramework="4.0">
       <assemblies>
         <add assembly="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />


### PR DESCRIPTION
This is crucial, for instance, on the first push of a big project as my anecdotal instance proved to me
