### PR TITLE
Fix for issue #55 where viewing repository files with a '+' in the path ...

### DIFF
--- a/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
+++ b/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -52,6 +53,7 @@
   <ItemGroup>
     <Compile Include="MsysgitIntegrationTests.cs" />
     <Compile Include="MsysgitResources.cs" />
+    <Compile Include="PathEncoderTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Definitions.cs" />
   </ItemGroup>

--- a/Bonobo.Git.Server.Test/PathEncoderTest.cs
+++ b/Bonobo.Git.Server.Test/PathEncoderTest.cs
@@ -1,0 +1,84 @@
+﻿using Bonobo.Git.Server.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using System.Web;
+
+namespace Bonobo.Git.Server.Test
+{
+    [TestClass]
+    public class PathEncoderTest
+    {
+        [TestMethod]
+        public void NullInput()
+        {
+            AssertAllRequirements(null);
+        }
+
+        [TestMethod]
+        public void EmptyInput()
+        {
+            AssertAllRequirements("");
+        }
+
+        [TestMethod]
+        public void SpaceInput()
+        {
+            AssertAllRequirements("     ");
+        }
+
+        [TestMethod]
+        public void LetterNumberInput()
+        {
+            AssertAllRequirements("abc123");
+        }
+
+        [TestMethod]
+        public void SymbolInput()
+        {
+            AssertAllRequirements("abc+def%ghi&jkl");
+        }
+
+        [TestMethod]
+        public void TypicalPathInput()
+        {
+            AssertAllRequirements("/folder/another folder/file name.c++");
+        }
+
+        [TestMethod]
+        public void AllByteCharacterInput()
+        {
+            AssertAllRequirements(GetStringCharacterRange(0, 255));
+        }
+
+        [TestMethod]
+        public void DoubleEncodeDecode()
+        {
+            var input = GetStringCharacterRange(30, 126); // Printable characters
+            Assert.AreEqual(input, PathEncoder.Decode(PathEncoder.Decode(PathEncoder.Encode(PathEncoder.Encode(input)))));
+        }
+
+        private static void AssertAllRequirements(string input)
+        {
+            AssertDecodeOfEncodeMatches(input);
+            AssertUrlDecodeDoesNotChange(input);
+        }
+
+        private static void AssertDecodeOfEncodeMatches(string input)
+        {
+            var encodedInput = PathEncoder.Encode(input);
+            Assert.AreEqual(input, PathEncoder.Decode(encodedInput));
+        }
+
+        private static void AssertUrlDecodeDoesNotChange(string input)
+        {
+            var encodedInput = PathEncoder.Encode(input);
+            var urlString = "http://localhost/" + encodedInput;
+            Assert.AreEqual(urlString, HttpUtility.UrlDecode(urlString));
+        }
+
+        private static string GetStringCharacterRange(int min, int max)
+        {
+            return new string(Enumerable.Range(min, max - min + 1).Select(i => (char)i).ToArray());
+        }
+    }
+}

--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -231,6 +231,7 @@
     <Compile Include="FileNameAttribute.cs" />
     <Compile Include="WebAuthorizeAttribute.cs" />
     <Compile Include="Helpers\CustomHtmlHelpers.cs" />
+    <Compile Include="Helpers\PathEncoder.cs" />
     <Compile Include="Models\HomeModels.cs" />
     <Compile Include="Models\RepositoryModels.cs" />
     <Compile Include="Models\SettingsModels.cs" />

--- a/Bonobo.Git.Server/Controllers/RepositoryController.cs
+++ b/Bonobo.Git.Server/Controllers/RepositoryController.cs
@@ -14,6 +14,7 @@ using System.Text.RegularExpressions;
 using Bonobo.Git.Server.Configuration;
 using LibGit2Sharp;
 using Bonobo.Git.Server.Extensions;
+using Bonobo.Git.Server.Helpers;
 
 namespace Bonobo.Git.Server.Controllers
 {
@@ -177,13 +178,14 @@ namespace Bonobo.Git.Server.Controllers
         }
 
         [WebAuthorizeRepository]
-        public ActionResult Tree(string id, string name, string path)
+        public ActionResult Tree(string id, string name, string encodedPath)
         {
             ViewBag.ID = id;
             if (!String.IsNullOrEmpty(id))
             {
                 using (var browser = new RepositoryBrowser(Path.Combine(UserConfiguration.Current.Repositories, id)))                 
                 {
+                    var path = PathEncoder.Decode(encodedPath);
                     string referenceName;
                     var files = browser.BrowseTree(name, path, out referenceName);
                     PopulateBranchesData(browser, referenceName);
@@ -200,13 +202,14 @@ namespace Bonobo.Git.Server.Controllers
         }
 
         [WebAuthorizeRepository]
-        public ActionResult Blob(string id, string name, string path)
+        public ActionResult Blob(string id, string name, string encodedPath)
         {
             ViewBag.ID = id;
             if (!String.IsNullOrEmpty(id))
             {
                 using (var browser = new RepositoryBrowser(Path.Combine(UserConfiguration.Current.Repositories, id)))
                 {
+                    var path = PathEncoder.Decode(encodedPath);
                     string referenceName;
                     var model = browser.BrowseBlob(name, path, out referenceName);
                     PopulateBranchesData(browser, referenceName);
@@ -226,13 +229,14 @@ namespace Bonobo.Git.Server.Controllers
         }
 
         [WebAuthorizeRepository]
-        public ActionResult Raw(string id, string name, string path)
+        public ActionResult Raw(string id, string name, string encodedPath)
         {
             ViewBag.ID = id;
             if (!String.IsNullOrEmpty(id))
             {
                 using (var browser = new RepositoryBrowser(Path.Combine(UserConfiguration.Current.Repositories, id)))
                 {
+                    var path = PathEncoder.Decode(encodedPath);
                     string referenceName;
                     var model = browser.BrowseBlob(name, path, out referenceName);
 

--- a/Bonobo.Git.Server/Global.asax.cs
+++ b/Bonobo.Git.Server/Global.asax.cs
@@ -42,14 +42,14 @@ namespace Bonobo.Git.Server
             routes.MapRoute("CreateRoute", "{controller}/Create/",
                             new { action = "Create" });
 
-            routes.MapRoute("RepositoryTree", "Repository/{id}/Tree/{name}/{*path}",
+            routes.MapRoute("RepositoryTree", "Repository/{id}/Tree/{name}/{*encodedPath}",
                             new { controller = "Repository", action = "Tree" });
             
-            routes.MapRoute("RepositoryBlob", "Repository/{id}/Blob/{name}/{*path}",
+            routes.MapRoute("RepositoryBlob", "Repository/{id}/Blob/{name}/{*encodedPath}",
                             new { controller = "Repository", action = "Blob" });
             
-            routes.MapRoute("RepositoryRaw", "Repository/{id}/Raw/{name}/{*path}",
-                            new { controller = "Repository", action = "Raw" });          
+            routes.MapRoute("RepositoryRaw", "Repository/{id}/Raw/{name}/{*encodedPath}",
+                            new { controller = "Repository", action = "Raw" });
 
             routes.MapRoute("RepositoryCommits", "Repository/{id}/Commits/{name}/",
                             new { controller = "Repository", action = "Commits" });

--- a/Bonobo.Git.Server/Helpers/PathEncoder.cs
+++ b/Bonobo.Git.Server/Helpers/PathEncoder.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Text;
+
+namespace Bonobo.Git.Server.Helpers
+{
+    /// <summary>
+    /// Helper class that encodes/decodes path fragments for safe use in a URL.
+    /// </summary>
+    /// <remarks>
+    /// Avoids triggering IIS's "HTTP Error 404.11 URL Double Escaped" exception
+    /// (http://support.microsoft.com/kb/942076) for paths with problem characters
+    /// like '+' by encoding/decoding path fragments via modified base 64 for URL
+    /// (http://en.wikipedia.org/wiki/Base_64).
+    /// </remarks>
+    public static class PathEncoder
+    {
+        /// <summary>
+        /// Encodes a path fragment.
+        /// </summary>
+        /// <param name="path">Path fragment.</param>
+        /// <returns>Encoded path fragment.</returns>
+        public static string Encode(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                // No need to encode; return as-is
+                return path;
+            }
+            return Convert.ToBase64String(Encoding.UTF8.GetBytes(path)).Replace('+', '-').Replace('/', '_');
+        }
+
+        /// <summary>
+        /// Decodes a path fragment.
+        /// </summary>
+        /// <param name="encodedPath">Path fragment.</param>
+        /// <returns>Decoded path fragment.</returns>
+        public static string Decode(string encodedPath)
+        {
+            if (string.IsNullOrEmpty(encodedPath))
+            {
+                // No need to decode; return as-is
+                return encodedPath;
+            }
+            return Encoding.UTF8.GetString(Convert.FromBase64String(encodedPath.Replace('-', '+').Replace('_', '/')));
+        }
+    }
+}

--- a/Bonobo.Git.Server/Views/Repository/Blob.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Blob.cshtml
@@ -16,12 +16,12 @@
         @Html.Partial("_AddressBar")
         @{
             <div class="controlPanel">
-                <p>@Html.ActionLink(@Resources.Repository_Tree_Download, "Raw", new { name = Model.TreeName, path = Model.Path }, new { @class = "downloadLink" })</p>
+                <p>@Html.ActionLink(@Resources.Repository_Tree_Download, "Raw", new { name = Model.TreeName, encodedPath = PathEncoder.Encode(Model.Path) }, new { @class = "downloadLink" })</p>
             </div>
         }
         @if (Model.IsImage)
         {
-            <img class="fileImage" alt="@Model.Name" src="@Url.Action("Raw", new { name = Model.TreeName, path = Model.Path })" />
+            <img class="fileImage" alt="@Model.Name" src="@Url.Action("Raw", new { name = Model.TreeName, encodedPath = PathEncoder.Encode(Model.Path) })" />
         }
         else if (Model.IsText)
         {

--- a/Bonobo.Git.Server/Views/Repository/Commit.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Commit.cshtml
@@ -1,5 +1,6 @@
 ﻿@model RepositoryCommitModel
 @using Bonobo.Git.Server.Extensions
+@using Bonobo.Git.Server.Helpers
 @{
     ViewBag.Title = Resources.Repository_Commit_Detail;
     Layout = "~/Views/Repository/_RepositoryLayout.cshtml";
@@ -45,7 +46,7 @@
                         }
                         @if (item.Status != LibGit2Sharp.ChangeKind.Deleted)
                         {
-                            @Html.ActionLink(item.Path, "Blob", new { id = ViewBag.ID, path = item.Path, name = Model.ID })
+                            @Html.ActionLink(item.Path, "Blob", new { id = ViewBag.ID, encodedPath = PathEncoder.Encode(item.Path), name = Model.ID })
                         }
                         else
                         {

--- a/Bonobo.Git.Server/Views/Repository/Tree.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Tree.cshtml
@@ -1,4 +1,5 @@
 ﻿@using Bonobo.Git.Server.Extensions
+@using Bonobo.Git.Server.Helpers
 @model RepositoryTreeModel
 @{
     Layout = "~/Views/Repository/_RepositoryLayout.cshtml";
@@ -22,7 +23,7 @@
                     headerStyle: "head",
                     alternatingRowStyle: "even",
                     columns: grid.Columns(
-                     grid.Column("Name", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("Name"), format: (item) => @Html.ActionLink((string)item.Name, item.IsTree ? "Tree" : "Blob", new { name = item.TreeName, path = item.Path }, new { @class = item.IsTree ? "directory" : item.IsImage ? "image" : "file" })),
+                     grid.Column("Name", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("Name"), format: (item) => @Html.ActionLink((string)item.Name, item.IsTree ? "Tree" : "Blob", new { name = item.TreeName, encodedPath = PathEncoder.Encode(item.Path) }, new { @class = item.IsTree ? "directory" : item.IsImage ? "image" : "file" })),
                         grid.Column("CommitMessage", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("CommitMessage")),
                         grid.Column("CommitDate", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("CommitDate"), format: item => ((DateTime)item.CommitDate).ToString(Resources.DateTimeFormat)),
                         grid.Column("Author", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("Author"))

--- a/Bonobo.Git.Server/Views/Repository/_AddressBar.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/_AddressBar.cshtml
@@ -2,7 +2,7 @@
     var path = ViewData["path"] as string;    
     
     <p id="repositoryAddress">
-        @Html.ActionLink(Resources.Repository_AddressBar_Root, "Tree", new { id = ViewBag.ID, name = ViewData["currentBranch"] ?? ViewData["name"], path = ""})
+        @Html.ActionLink(Resources.Repository_AddressBar_Root, "Tree", new { id = ViewBag.ID, name = ViewData["currentBranch"] ?? ViewData["name"], encodedPath = ""})
         @if (path != null)
         {
             <text>/</text>
@@ -22,7 +22,7 @@
                 }
                 else
                 {
-                    @Html.ActionLink(dirs[i], "Tree", new { path = currentPath, id = ViewBag.ID })                    
+                    @Html.ActionLink(dirs[i], "Tree", new { encodedPath = PathEncoder.Encode(currentPath), id = ViewBag.ID })
                 }
 
                 if (i + 1 != dirs.Length)

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ tags: [Changelog, Changes, Bug Fixes, Features]
 
 ### Bug Fixes
 
+* Fixed a crash viewing files with a '+' in the path
+
 
 <hr />
 


### PR DESCRIPTION
...fails with an IIS error

Problem:
By default, IIS 7 (and later) throws a "HTTP Error 404.11 URL Double Escaped" error if the request URL contains characters that represent an escape sequence (http://support.microsoft.com/kb/942076). This is a site/application-level setting and security measure, so it is preferable not to require a change from the default (more secure) value. The '+' character is a legal path character for files in a GIT repository and triggers the above error when used with Bonobo's Tree/Blob/Raw controllers as part of a path reference.

Discarded approach:
Encode the '+' character in URLs with a custom encoding scheme. This idea was rejected because it is non-standard and the encoding/escape character may conflict with valid path names or fail to include other problematic characters (see below for an example).

Proposed approach:
Encode/decode path fragments with the standard "modified base 64 for URL" encoding (http://en.wikipedia.org/wiki/Base_64). This solves the reported problem with '+' as well as avoids similar URL/encoding problems for other troublesome GIT paths. Specifically, this change solves an unreported problem where viewing a file with a '&' character in the path results in "HttpException (0x80004005): A potentially dangerous Request.Path value was detected from the client (&)." (an exception which is not affected by the requestFiltering/allowDoubleEscaping setting for '+'). The downside of the proposed approach is that the path fragment in the URL is no longer human-readable.

Discarded approach:
A hybrid solution of the previous two, because of the additional complexity and risk of overlooking another problem character.

Implementation:
A new PathEncoder class is added to the Helpers namespace and exposes Encode/Decode methods. The implementation uses .NET's Convert.To/FromBase64String methods plus substitutions for '+' and '/' (per the base 64 convention for URLs), and can be easily changed to another suitable encoding without requiring other changes (because the relevant scenarios all now go through PathEncoder). A corresponding set of unit tests for PathEncoder is added to the test project to verify encode/decode correctness and the absence of double-escape characters in the encoded text.

Routes for the Tree/Blob/Raw actions are updated to use "encodedPath" instead of "path", the corresponding controllers decode the encoded path before using it, and the corresponding links encode the path in their URLs.

changelog.md is updated accordingly.

Note: A similar change to encode the "name" route parameter should fix issue #54; I will look into that if this change gets accepted.
