### PR TITLE
Follow-up of fix for issue #55: Change the path encoding to be human-rea...

### DIFF
--- a/Bonobo.Git.Server.Test/PathEncoderTest.cs
+++ b/Bonobo.Git.Server.Test/PathEncoderTest.cs
@@ -1,5 +1,6 @@
 ﻿using Bonobo.Git.Server.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Linq;
 using System.Web;
 
@@ -35,7 +36,14 @@ namespace Bonobo.Git.Server.Test
         [TestMethod]
         public void SymbolInput()
         {
-            AssertAllRequirements("abc+def%ghi&jkl");
+            AssertAllRequirements("abc+def%ghi&jkl/mno\\pqr#stu~vwx-yz");
+        }
+
+        [TestMethod]
+        public void UnicodeInput()
+        {
+            // Sample characters from http://en.wikipedia.org/wiki/Unicode_and_HTML
+            AssertAllRequirements("\u0041\u00df\u00fe\u0394\u017d\u0419\u05e7\u0645\u0e57\u1250\u3042\u53f6\u8449\ub5ab\u16a0\u0d37");
         }
 
         [TestMethod]
@@ -55,6 +63,40 @@ namespace Bonobo.Git.Server.Test
         {
             var input = GetStringCharacterRange(30, 126); // Printable characters
             Assert.AreEqual(input, PathEncoder.Decode(PathEncoder.Decode(PathEncoder.Encode(PathEncoder.Encode(input)))));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void NonByteCharacterInput()
+        {
+            PathEncoder.Decode("\u0394");
+        }
+
+        [TestMethod]
+        public void MissingNoNibbles()
+        {
+            Assert.AreEqual("\0", PathEncoder.Decode("~00"));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void MissingOneNibble()
+        {
+            PathEncoder.Decode("~0");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void MissingBothNibbles()
+        {
+            PathEncoder.Decode("~");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void BadNibbleValues()
+        {
+            PathEncoder.Decode("~no");
         }
 
         private static void AssertAllRequirements(string input)

--- a/Bonobo.Git.Server/Helpers/PathEncoder.cs
+++ b/Bonobo.Git.Server/Helpers/PathEncoder.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace Bonobo.Git.Server.Helpers
@@ -9,8 +11,12 @@ namespace Bonobo.Git.Server.Helpers
     /// <remarks>
     /// Avoids triggering IIS's "HTTP Error 404.11 URL Double Escaped" exception
     /// (http://support.microsoft.com/kb/942076) for paths with problem characters
-    /// like '+' by encoding/decoding path fragments via modified base 64 for URL
-    /// (http://en.wikipedia.org/wiki/Base_64).
+    /// like '+' by encoding/decoding path fragments in a manner similar to URL
+    /// encoding (http://en.wikipedia.org/wiki/Percent-encoding) except that '~'
+    /// is used as the escape character instead of '%' and ' ' is encoded instead
+    /// of being mapped to '+'. '~' was chosen as the escape character because it
+    /// avoids the double encoding problem of '%' and is the least commonly used
+    /// unreserved character in path fragments.
     /// </remarks>
     public static class PathEncoder
     {
@@ -21,12 +27,38 @@ namespace Bonobo.Git.Server.Helpers
         /// <returns>Encoded path fragment.</returns>
         public static string Encode(string path)
         {
+            // Check for trivial input
             if (string.IsNullOrEmpty(path))
             {
                 // No need to encode; return as-is
                 return path;
             }
-            return Convert.ToBase64String(Encoding.UTF8.GetBytes(path)).Replace('+', '-').Replace('/', '_');
+            // Convert input to a sequence of bytes
+            var bytes = Encoding.UTF8.GetBytes(path);
+            // Create a StringBuilder with the expected (best case/minimum) size
+            var sb = new StringBuilder(bytes.Length);
+            // Encode each byte
+            foreach (var b in bytes)
+            {
+                /// RFC 3986 section 2.3 "Unreserved Characters" (http://tools.ietf.org/html/rfc3986):
+                /// ALPHA / DIGIT / '-' / '.' / '_' / '~'
+                if ((('a' <= b) && (b <= 'z')) || // a-z
+                    (('A' <= b) && (b <= 'Z')) || // A-Z
+                    (('0' <= b) && (b <= '9')) || // 0-9
+                    ('-' == b) || ('.' == b) || ('_' == b)) // - . _
+                {
+                    // Unreserved characters don't need encoding
+                    sb.Append((char)b);
+                }
+                else
+                {
+                    // Other characters (including the escape character '~') get URL encoded
+                    sb.Append('~');
+                    sb.Append(b.ToString("x2", CultureInfo.InvariantCulture));
+                }
+            }
+            // Return encoded string
+            return sb.ToString();
         }
 
         /// <summary>
@@ -36,12 +68,49 @@ namespace Bonobo.Git.Server.Helpers
         /// <returns>Decoded path fragment.</returns>
         public static string Decode(string encodedPath)
         {
+            // Check for trivial input
             if (string.IsNullOrEmpty(encodedPath))
             {
                 // No need to decode; return as-is
                 return encodedPath;
             }
-            return Encoding.UTF8.GetString(Convert.FromBase64String(encodedPath.Replace('-', '+').Replace('_', '/')));
+            // Capture length
+            var encodedPathLength = encodedPath.Length;
+            // Create a list of bytes with the maximum (typical) size
+            var bytes = new List<byte>(encodedPathLength);
+            // Decode each byte
+            for (var i = 0; i < encodedPathLength; i++)
+            {
+                // Capture current char/byte
+                var c = encodedPath[i];
+                var b = (byte)c;
+                if (c != b)
+                {
+                    // Throw for invalid input (non-byte character)
+                    throw new FormatException("Invalid non-byte input character.");
+                }
+                if ('~' == b)
+                {
+                    // Decode URL encoded character
+                    byte value;
+                    if ((encodedPathLength <= i + 2) ||
+                        !byte.TryParse(encodedPath.Substring(i + 1, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value))
+                    {
+                        // Throw for invalid input (insufficient space or non-hex value)
+                        throw new FormatException("Invalid format for encoded path character.");
+                    }
+                    // Add decoded byte and advance index
+                    bytes.Add(value);
+                    i += 2;
+                }
+                else
+                {
+                    // Add unreserved characters as-is
+                    bytes.Add(b);
+                }
+            }
+            // Return decoded string
+            return Encoding.UTF8.GetString(bytes.ToArray());
         }
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,7 @@ tags: [Changelog, Changes, Bug Fixes, Features]
 
 ### Bug Fixes
 
-* Fixed a crash viewing files with a '+' in the path
+* Fixed a crash viewing files with a '+' or '&' in the path
 
 
 <hr />


### PR DESCRIPTION
...dable for typical path names

The PathEncoder class is changed from using the "base 64 for URL" encoding to a custom implementation of the conventional "URL/percent encoding" scheme. Per the updated class comments:
/// Avoids triggering IIS's "HTTP Error 404.11 URL Double Escaped" exception
/// (http://support.microsoft.com/kb/942076) for paths with problem characters
/// like '+' by encoding/decoding path fragments in a manner similar to URL
/// encoding (http://en.wikipedia.org/wiki/Percent-encoding) except that '~'
/// is used as the escape character instead of '%' and ' ' is encoded instead
/// of being mapped to '+'. '~' was chosen as the escape character because it
/// avoids the double encoding problem of '%' and is the least commonly used
/// unreserved character in path fragments.

Characters in the RFC 3986 section 2.3 "Unreserved Characters" (http://tools.ietf.org/html/rfc3986) list (ALPHA / DIGIT / '-' / '.' / '_' / '~') are not changed by the new encoding scheme; all other characters are transformed. In particular, '/' and '\' are encoded, so it should be straightforward to fix issue #54 by an encoding of the "name" route parameter similar to how "path" is encoded. (I plan to do this in the next pull request.)

The new encoding means that for all typical cases the URLs for Tree/Blob/Raw controllers are unchanged from before the introduction of PathEncoder and are exact matches of the human-readable names for the corresponding repository files/paths (i.e., "file.txt"=>"file.txt").

The PathEncoderTest class is enhanced with 6 new tests (and 1 tweaked test) to verify the custom encoding implementation behaves correctly. These tests achieve 100% code coverage of the PathEncoder class.

changelog.md is tweaked to note that the fix applies to '&' as well as '+'.
