### PR TITLE
Fix for issue #54 where branches (and tags) with '/' in the name could n...

### DIFF
--- a/Bonobo.Git.Server/Controllers/RepositoryController.cs
+++ b/Bonobo.Git.Server/Controllers/RepositoryController.cs
@@ -178,13 +178,14 @@ namespace Bonobo.Git.Server.Controllers
         }
 
         [WebAuthorizeRepository]
-        public ActionResult Tree(string id, string name, string encodedPath)
+        public ActionResult Tree(string id, string encodedName, string encodedPath)
         {
             ViewBag.ID = id;
             if (!String.IsNullOrEmpty(id))
             {
-                using (var browser = new RepositoryBrowser(Path.Combine(UserConfiguration.Current.Repositories, id)))                 
+                using (var browser = new RepositoryBrowser(Path.Combine(UserConfiguration.Current.Repositories, id)))
                 {
+                    var name = PathEncoder.Decode(encodedName);
                     var path = PathEncoder.Decode(encodedPath);
                     string referenceName;
                     var files = browser.BrowseTree(name, path, out referenceName);
@@ -202,13 +203,14 @@ namespace Bonobo.Git.Server.Controllers
         }
 
         [WebAuthorizeRepository]
-        public ActionResult Blob(string id, string name, string encodedPath)
+        public ActionResult Blob(string id, string encodedName, string encodedPath)
         {
             ViewBag.ID = id;
             if (!String.IsNullOrEmpty(id))
             {
                 using (var browser = new RepositoryBrowser(Path.Combine(UserConfiguration.Current.Repositories, id)))
                 {
+                    var name = PathEncoder.Decode(encodedName);
                     var path = PathEncoder.Decode(encodedPath);
                     string referenceName;
                     var model = browser.BrowseBlob(name, path, out referenceName);
@@ -229,13 +231,14 @@ namespace Bonobo.Git.Server.Controllers
         }
 
         [WebAuthorizeRepository]
-        public ActionResult Raw(string id, string name, string encodedPath)
+        public ActionResult Raw(string id, string encodedName, string encodedPath)
         {
             ViewBag.ID = id;
             if (!String.IsNullOrEmpty(id))
             {
                 using (var browser = new RepositoryBrowser(Path.Combine(UserConfiguration.Current.Repositories, id)))
                 {
+                    var name = PathEncoder.Decode(encodedName);
                     var path = PathEncoder.Decode(encodedPath);
                     string referenceName;
                     var model = browser.BrowseBlob(name, path, out referenceName);
@@ -247,13 +250,14 @@ namespace Bonobo.Git.Server.Controllers
         }
 
         [WebAuthorizeRepository]
-        public ActionResult Commits(string id, string name)
+        public ActionResult Commits(string id, string encodedName)
         {
             ViewBag.ID = id;
             if (!String.IsNullOrEmpty(id))
             {
                 using (var browser = new RepositoryBrowser(Path.Combine(UserConfiguration.Current.Repositories, id)))
                 {
+                    var name = PathEncoder.Decode(encodedName);
                     string referenceName;
                     var commits = browser.GetCommits(name, out referenceName);
                     PopulateBranchesData(browser, referenceName);

--- a/Bonobo.Git.Server/Global.asax.cs
+++ b/Bonobo.Git.Server/Global.asax.cs
@@ -42,16 +42,16 @@ namespace Bonobo.Git.Server
             routes.MapRoute("CreateRoute", "{controller}/Create/",
                             new { action = "Create" });
 
-            routes.MapRoute("RepositoryTree", "Repository/{id}/Tree/{name}/{*encodedPath}",
+            routes.MapRoute("RepositoryTree", "Repository/{id}/Tree/{encodedName}/{*encodedPath}",
                             new { controller = "Repository", action = "Tree" });
-            
-            routes.MapRoute("RepositoryBlob", "Repository/{id}/Blob/{name}/{*encodedPath}",
+
+            routes.MapRoute("RepositoryBlob", "Repository/{id}/Blob/{encodedName}/{*encodedPath}",
                             new { controller = "Repository", action = "Blob" });
-            
-            routes.MapRoute("RepositoryRaw", "Repository/{id}/Raw/{name}/{*encodedPath}",
+
+            routes.MapRoute("RepositoryRaw", "Repository/{id}/Raw/{encodedName}/{*encodedPath}",
                             new { controller = "Repository", action = "Raw" });
 
-            routes.MapRoute("RepositoryCommits", "Repository/{id}/Commits/{name}/",
+            routes.MapRoute("RepositoryCommits", "Repository/{id}/Commits/{encodedName}/",
                             new { controller = "Repository", action = "Commits" });
 
             routes.MapRoute("RepositoryCommit", "Repository/{id}/Commit/{commit}/",

--- a/Bonobo.Git.Server/Views/Repository/Blob.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Blob.cshtml
@@ -16,12 +16,12 @@
         @Html.Partial("_AddressBar")
         @{
             <div class="controlPanel">
-                <p>@Html.ActionLink(@Resources.Repository_Tree_Download, "Raw", new { name = Model.TreeName, encodedPath = PathEncoder.Encode(Model.Path) }, new { @class = "downloadLink" })</p>
+                <p>@Html.ActionLink(@Resources.Repository_Tree_Download, "Raw", new { encodedName = PathEncoder.Encode(Model.TreeName), encodedPath = PathEncoder.Encode(Model.Path) }, new { @class = "downloadLink" })</p>
             </div>
         }
         @if (Model.IsImage)
         {
-            <img class="fileImage" alt="@Model.Name" src="@Url.Action("Raw", new { name = Model.TreeName, encodedPath = PathEncoder.Encode(Model.Path) })" />
+            <img class="fileImage" alt="@Model.Name" src="@Url.Action("Raw", new { encodedName = PathEncoder.Encode(Model.TreeName), encodedPath = PathEncoder.Encode(Model.Path) })" />
         }
         else if (Model.IsText)
         {

--- a/Bonobo.Git.Server/Views/Repository/Commit.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Commit.cshtml
@@ -1,6 +1,5 @@
 ﻿@model RepositoryCommitModel
 @using Bonobo.Git.Server.Extensions
-@using Bonobo.Git.Server.Helpers
 @{
     ViewBag.Title = Resources.Repository_Commit_Detail;
     Layout = "~/Views/Repository/_RepositoryLayout.cshtml";
@@ -46,7 +45,7 @@
                         }
                         @if (item.Status != LibGit2Sharp.ChangeKind.Deleted)
                         {
-                            @Html.ActionLink(item.Path, "Blob", new { id = ViewBag.ID, encodedPath = PathEncoder.Encode(item.Path), name = Model.ID })
+                            @Html.ActionLink(item.Path, "Blob", new { id = ViewBag.ID, encodedPath = PathEncoder.Encode(item.Path), encodedName = PathEncoder.Encode(Model.ID) })
                         }
                         else
                         {

--- a/Bonobo.Git.Server/Views/Repository/Tree.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Tree.cshtml
@@ -1,5 +1,4 @@
 ﻿@using Bonobo.Git.Server.Extensions
-@using Bonobo.Git.Server.Helpers
 @model RepositoryTreeModel
 @{
     Layout = "~/Views/Repository/_RepositoryLayout.cshtml";
@@ -23,7 +22,7 @@
                     headerStyle: "head",
                     alternatingRowStyle: "even",
                     columns: grid.Columns(
-                     grid.Column("Name", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("Name"), format: (item) => @Html.ActionLink((string)item.Name, item.IsTree ? "Tree" : "Blob", new { name = item.TreeName, encodedPath = PathEncoder.Encode(item.Path) }, new { @class = item.IsTree ? "directory" : item.IsImage ? "image" : "file" })),
+                     grid.Column("Name", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("Name"), format: (item) => @Html.ActionLink((string)item.Name, item.IsTree ? "Tree" : "Blob", new { encodedName = PathEncoder.Encode(item.TreeName), encodedPath = PathEncoder.Encode(item.Path) }, new { @class = item.IsTree ? "directory" : item.IsImage ? "image" : "file" })),
                         grid.Column("CommitMessage", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("CommitMessage")),
                         grid.Column("CommitDate", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("CommitDate"), format: item => ((DateTime)item.CommitDate).ToString(Resources.DateTimeFormat)),
                         grid.Column("Author", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("Author"))

--- a/Bonobo.Git.Server/Views/Repository/_AddressBar.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/_AddressBar.cshtml
@@ -1,8 +1,8 @@
 ﻿@{
-    var path = ViewData["path"] as string;    
-    
+    var path = ViewData["path"] as string;
+
     <p id="repositoryAddress">
-        @Html.ActionLink(Resources.Repository_AddressBar_Root, "Tree", new { id = ViewBag.ID, name = ViewData["currentBranch"] ?? ViewData["name"], encodedPath = ""})
+        @Html.ActionLink(Resources.Repository_AddressBar_Root, "Tree", new { id = ViewBag.ID, encodedName = PathEncoder.Encode((string)(ViewData["currentBranch"] ?? ViewData["name"])), encodedPath = ""})
         @if (path != null)
         {
             <text>/</text>
@@ -27,7 +27,7 @@
 
                 if (i + 1 != dirs.Length)
                 {
-                        <text>/</text>
+                    <text>/</text>
                 }
             }
         }

--- a/Bonobo.Git.Server/Views/Repository/_BranchSwitcher.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/_BranchSwitcher.cshtml
@@ -7,11 +7,11 @@
                 var action = ViewContext.RouteData.Values["Action"].ToString() == "Blob" ? "Tree" : ViewContext.RouteData.Values["Action"].ToString();
                 foreach (var item in ViewData["branches"] as IEnumerable<string>)
                 {
-                    <li class="@(String.Equals(ViewData["referenceName"], item) ? "branchactive" : "branchinactive")">@Html.ActionLink(item as string, action, new { name = item, path = String.Empty })</li>
+                    <li class="@(String.Equals(ViewData["referenceName"], item) ? "branchactive" : "branchinactive")">@Html.ActionLink(item as string, action, new { encodedName = PathEncoder.Encode(item), encodedPath = String.Empty })</li>
                 }
                 foreach (var item in ViewData["tags"] as IEnumerable<string>)
                 {
-                    <li class="@(String.Equals(ViewData["referenceName"], item) ? "tagactive" : "taginactive")">@Html.ActionLink(item as string, action, new { name = item, path = String.Empty })</li>
+                    <li class="@(String.Equals(ViewData["referenceName"], item) ? "tagactive" : "taginactive")">@Html.ActionLink(item as string, action, new { encodedName = PathEncoder.Encode(item), encodedPath = String.Empty })</li>
                 }
             }
         </ul>

--- a/Bonobo.Git.Server/Views/Repository/_Commit.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/_Commit.cshtml
@@ -1,5 +1,5 @@
 ﻿@model RepositoryCommitModel
-@using Bonobo.Git.Server.Extensions           
+@using Bonobo.Git.Server.Extensions
 <h4 class="commitDate">@Model.Date.ToString(Resources.DateTimeFormat)</h4>
 <div class="commit">      
 <div class="window">
@@ -10,7 +10,7 @@
     </div>
     <div class="fr">
         <p><em>@Model.GetType().GetDisplayValue("ID"):</em> @Html.ActionLink(Model.ID, "Commit", new { id = ViewBag.ID, commit = Model.ID })</p>
-        <p><em>@Model.GetType().GetDisplayValue("TreeID"):</em> @Html.ActionLink(Model.TreeID, "Tree", new { id = ViewBag.ID, name = Model.ID })</p>
+        <p><em>@Model.GetType().GetDisplayValue("TreeID"):</em> @Html.ActionLink(Model.TreeID, "Tree", new { id = ViewBag.ID, encodedName = PathEncoder.Encode(Model.ID) })</p>
         @if (Model.Parents != null && Model.Parents.Count() > 0)
         {
             <p>

--- a/Bonobo.Git.Server/Views/Repository/_RepositoryLayout.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/_RepositoryLayout.cshtml
@@ -11,8 +11,8 @@ else
     <h2>@Resources.Repository_Detail_Title</h2>
     <ul id="repositoryMenu" class="clearfix">
         <li>@Html.ActionLink(Resources.Repository_Detail_Detail, "Detail", new { id = ViewBag.ID }, new { @class = "detail"})</li>
-        <li>@Html.ActionLink(Resources.Repository_Layout_Browse, "Tree", new { id = ViewBag.ID, name = UrlParameter.Optional }, new { @class = "browser" })</li>
-        <li>@Html.ActionLink(Resources.Repository_Layout_Commits, "Commits", new { id = ViewBag.ID, name = UrlParameter.Optional }, new { @class = "commits" })</li>     
+        <li>@Html.ActionLink(Resources.Repository_Layout_Browse, "Tree", new { id = ViewBag.ID, encodedName = UrlParameter.Optional }, new { @class = "browser" })</li>
+        <li>@Html.ActionLink(Resources.Repository_Layout_Commits, "Commits", new { id = ViewBag.ID, encodedName = UrlParameter.Optional }, new { @class = "commits" })</li>
     </ul> 
     </text>
 }

--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,8 @@ tags: [Changelog, Changes, Bug Fixes, Features]
 
 ### Bug Fixes
 
-* Fixed a crash viewing files with a '+' or '&' in the path
+* Fixed a problem viewing files with '+' or '&' in the path
+* Fixed a problem viewing branches and tags with '/' in the name
 
 
 <hr />


### PR DESCRIPTION
...ot be viewed

Use the PathEncoder class (introduced to fix issue #55) to encode branch and tag names (in addition to repository paths) when used with the Tree/Blob/Raw/Commits controllers. All non-RFC 3986 unreserved characters in branch and tag names are encoded (in a manner similar to URL/percent encoding) and will not be mis-interpreted by IIS as URL components.

changelog.md is updated to describe the fix.

A few instances of trailing whitespace and two unnecessary @usings were removed.
