### PR TITLE
Add an allowSlash parameter to the PathEncoder.Encode method (default va...

### DIFF
--- a/Bonobo.Git.Server/Helpers/PathEncoder.cs
+++ b/Bonobo.Git.Server/Helpers/PathEncoder.cs
@@ -24,8 +24,9 @@ namespace Bonobo.Git.Server.Helpers
         /// Encodes a path fragment.
         /// </summary>
         /// <param name="path">Path fragment.</param>
+        /// <param name="allowSlash">True if '/' should be allowed (i.e., not encoded).</param>
         /// <returns>Encoded path fragment.</returns>
-        public static string Encode(string path)
+        public static string Encode(string path, bool allowSlash = false)
         {
             // Check for trivial input
             if (string.IsNullOrEmpty(path))
@@ -45,7 +46,8 @@ namespace Bonobo.Git.Server.Helpers
                 if ((('a' <= b) && (b <= 'z')) || // a-z
                     (('A' <= b) && (b <= 'Z')) || // A-Z
                     (('0' <= b) && (b <= '9')) || // 0-9
-                    ('-' == b) || ('.' == b) || ('_' == b)) // - . _
+                    ('-' == b) || ('.' == b) || ('_' == b) || // - . _
+                    (allowSlash && ('/' == b))) // Allow /
                 {
                     // Unreserved characters don't need encoding
                     sb.Append((char)b);

--- a/Bonobo.Git.Server/Views/Repository/Blob.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Blob.cshtml
@@ -16,12 +16,12 @@
         @Html.Partial("_AddressBar")
         @{
             <div class="controlPanel">
-                <p>@Html.ActionLink(@Resources.Repository_Tree_Download, "Raw", new { encodedName = PathEncoder.Encode(Model.TreeName), encodedPath = PathEncoder.Encode(Model.Path) }, new { @class = "downloadLink" })</p>
+                <p>@Html.ActionLink(@Resources.Repository_Tree_Download, "Raw", new { encodedName = PathEncoder.Encode(Model.TreeName), encodedPath = PathEncoder.Encode(Model.Path, allowSlash: true) }, new { @class = "downloadLink" })</p>
             </div>
         }
         @if (Model.IsImage)
         {
-            <img class="fileImage" alt="@Model.Name" src="@Url.Action("Raw", new { encodedName = PathEncoder.Encode(Model.TreeName), encodedPath = PathEncoder.Encode(Model.Path) })" />
+            <img class="fileImage" alt="@Model.Name" src="@Url.Action("Raw", new { encodedName = PathEncoder.Encode(Model.TreeName), encodedPath = PathEncoder.Encode(Model.Path, allowSlash: true) })" />
         }
         else if (Model.IsText)
         {

--- a/Bonobo.Git.Server/Views/Repository/Commit.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Commit.cshtml
@@ -45,7 +45,7 @@
                         }
                         @if (item.Status != LibGit2Sharp.ChangeKind.Deleted)
                         {
-                            @Html.ActionLink(item.Path, "Blob", new { id = ViewBag.ID, encodedPath = PathEncoder.Encode(item.Path), encodedName = PathEncoder.Encode(Model.ID) })
+                            @Html.ActionLink(item.Path, "Blob", new { id = ViewBag.ID, encodedPath = PathEncoder.Encode(item.Path, allowSlash: true), encodedName = PathEncoder.Encode(Model.ID) })
                         }
                         else
                         {

--- a/Bonobo.Git.Server/Views/Repository/Tree.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Tree.cshtml
@@ -22,7 +22,7 @@
                     headerStyle: "head",
                     alternatingRowStyle: "even",
                     columns: grid.Columns(
-                     grid.Column("Name", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("Name"), format: (item) => @Html.ActionLink((string)item.Name, item.IsTree ? "Tree" : "Blob", new { encodedName = PathEncoder.Encode(item.TreeName), encodedPath = PathEncoder.Encode(item.Path) }, new { @class = item.IsTree ? "directory" : item.IsImage ? "image" : "file" })),
+                        grid.Column("Name", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("Name"), format: (item) => @Html.ActionLink((string)item.Name, item.IsTree ? "Tree" : "Blob", new { encodedName = PathEncoder.Encode(item.TreeName), encodedPath = PathEncoder.Encode(item.Path, allowSlash: true) }, new { @class = item.IsTree ? "directory" : item.IsImage ? "image" : "file" })),
                         grid.Column("CommitMessage", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("CommitMessage")),
                         grid.Column("CommitDate", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("CommitDate"), format: item => ((DateTime)item.CommitDate).ToString(Resources.DateTimeFormat)),
                         grid.Column("Author", header: typeof(RepositoryTreeDetailModel).GetDisplayValue("Author"))

--- a/Bonobo.Git.Server/Views/Repository/_AddressBar.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/_AddressBar.cshtml
@@ -22,7 +22,7 @@
                 }
                 else
                 {
-                    @Html.ActionLink(dirs[i], "Tree", new { encodedPath = PathEncoder.Encode(currentPath), id = ViewBag.ID })
+                    @Html.ActionLink(dirs[i], "Tree", new { encodedPath = PathEncoder.Encode(currentPath, allowSlash: true), id = ViewBag.ID })
                 }
 
                 if (i + 1 != dirs.Length)


### PR DESCRIPTION
...lue: false) that allows callers to allow the '/' character to be passed through un-encoded. Add corresponding unit tests to verify the new functionality. Update URL creation for Tree/Blob/Raw to pass allowSlash=true so the {*encodedPath} portion of the route will look more like the directory structure of the repository (ex: "Blob/master/dir1/dir2/file").
