### PR TITLE
Customize table/grid layout in Tree view for better display of long file...

### DIFF
--- a/Bonobo.Git.Server/Content/Site.css
+++ b/Bonobo.Git.Server/Content/Site.css
@@ -141,6 +141,15 @@ div.uniForm #errorMsg { text-align: center;}
 #TeamIndex .team {background: url('images/team.png') no-repeat 0px 2px;}
 #RepositoryIndex .repository {background: url('images/repository.png') no-repeat 0px 2px;}
 
+/* Table Layout for Tree */
+
+#RepositoryTree table { table-layout: fixed; }
+#RepositoryTree th:nth-child(1) { width: 30%; }
+#RepositoryTree th:nth-child(2) { width: 30%; }
+#RepositoryTree th:nth-child(3) { width: 20%; }
+#RepositoryTree th:nth-child(4) { width: 20%; }
+#RepositoryTree .file, #RepositoryTree .image, #RepositoryTree .directory { width: auto; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
 /* Repository */
 
 #RepositoryTree .fileImage { width: 100%;}


### PR DESCRIPTION
... names.

Prior to this change, long strings in the Name column would either overlap text in the Message column or else wrap within the column and overlap the following Name (depending on whether the Name included a break character like ' ' or '-'). This CSS-only change tweaks the table layout to give more room to the Name/Message columns, prevent wrapping of text in the Name column, and enable ellipsis ('…') for truncated text.

---

Two notes:
- Please feel free to tweak any values here - especially the column widths! What I've proposed is a first attempt to correct some ugly wrapping/overlapping I saw when working on URL encoding and using long directory/file names. table-layout:fixed makes it so the TH sizes are respected instead of using HTML's flexible table layout code which varies the widths in all kinds of weird ways.
- I tried adding the title= attribute to the A element, but it shows ALL the time (not just when the ellipsis is used) and that seemed bad. The way it is now, clicking on any "truncated file..." goes to the Blob view which shows the complete name as before.
