### PR TITLE
Switch RepositoryCommitModel to use Commit.Message instead of Commit.Mes...

### DIFF
--- a/Bonobo.Git.Server/RepositoryBrowser.cs
+++ b/Bonobo.Git.Server/RepositoryBrowser.cs
@@ -153,7 +153,7 @@ namespace Bonobo.Git.Server
                 AuthorEmail = commit.Author.Email,
                 Date = commit.Author.When.LocalDateTime,
                 ID = commit.Sha,
-                Message = commit.MessageShort,
+                Message = commit.Message,
                 TreeID = commit.Tree.Sha,
                 Parents = commit.Parents.Select(i => i.Sha).ToArray(),
             };


### PR DESCRIPTION
...sageShort so the complete text of the commit message will be available in the Commits and Commit views.

Note: Commit.Message includes embedded '\n' characters as-is; this change does not attempt to translate them to line-breaks (ex: via "BR/").

---

Without something like this change, there doesn't seem to be a way to see the complete message of a commit.
