### PR TITLE
CssRewriteUrlTransform doesn't account for virtual paths

### DIFF
--- a/Bonobo.Git.Server/App_Start/BundleConfig.cs
+++ b/Bonobo.Git.Server/App_Start/BundleConfig.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Optimization;
+﻿using Bonobo.Git.Server.Helpers;
+using System.Web.Optimization;
 
 namespace Bonobo.Git.Server.App_Start
 {
@@ -14,8 +15,8 @@ namespace Bonobo.Git.Server.App_Start
                 .Include("~/Content/components/highlight/build/lib/highlight.pack.js"));
 
             bundles.Add(new StyleBundle("~/Content/bundled.css")
-                .Include("~/Content/components/pure/pure-min.css", new CssRewriteUrlTransform())
-                .Include("~/Content/components/font-awesome/css/font-awesome.min.css", new CssRewriteUrlTransform())
+                .Include("~/Content/components/pure/pure-min.css", new CssRewriteUrlTransformWrapper())
+                .Include("~/Content/components/font-awesome/css/font-awesome.min.css", new CssRewriteUrlTransformWrapper())
                 .Include("~/Content/components/highlight/src/styles/github.css")
                 .Include("~/Content/fonts.css", "~/Content/site.css"));
         }

--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -264,6 +264,7 @@
     <Compile Include="Attributes\WebAuthorizeAttribute.cs" />
     <Compile Include="GitCmdResult.cs" />
     <Compile Include="Helpers\ContentDispositionUtil.cs" />
+    <Compile Include="Helpers\CssRewriteUrlTransformWrapper.cs" />
     <Compile Include="Helpers\CustomHtmlHelpers.cs" />
     <Compile Include="Helpers\PathEncoder.cs" />
     <Compile Include="Models\HomeModels.cs" />

--- a/Bonobo.Git.Server/Helpers/CssRewriteUrlTransformWrapper.cs
+++ b/Bonobo.Git.Server/Helpers/CssRewriteUrlTransformWrapper.cs
@@ -1,0 +1,15 @@
+﻿using System.Web;
+using System.Web.Optimization;
+
+namespace Bonobo.Git.Server.Helpers
+{
+    public class CssRewriteUrlTransformWrapper : IItemTransform
+    {
+        public string Process(string includedVirtualPath, string input)
+        {
+            return new CssRewriteUrlTransform().Process(
+                "~" + VirtualPathUtility.ToAbsolute(includedVirtualPath),
+                input);
+        }
+    }
+}


### PR DESCRIPTION
When processing CSS files in a bundle, the CssRewriteUrlTransform class
doesn't account for virtual paths, instead assuming that the application
is located at the domain root (assumes http://foobar.com/, but it's
actually http://foobar.com/Git).  This change implements a new wrapper
class that ensures that virtual directories are taken into account.

Since it just modifies the path and then passes it to the original
class, this should be low risk.  If the bug is ever fixed in the
framework there will be a regression, but the bug will leave users no
worse off than they are now.

Found solution from http://aspnetoptimization.codeplex.com/workitem/83
via
http://stackoverflow.com/questions/19765238/cssrewriteurltransform-with-or-without-virtual-directory

Tested the change using IIS Express on my local machine (no virtual path
required) and on my production IIS server (using a virtual path).  Both
tests were successful.
