### PR TITLE
Fix crash when repo contains GitLink node

### DIFF
--- a/Bonobo.Git.Server/Controllers/RepositoryController.cs
+++ b/Bonobo.Git.Server/Controllers/RepositoryController.cs
@@ -303,7 +303,11 @@ namespace Bonobo.Git.Server.Controllers
 
             foreach (var item in treeNode)
             {
-                if (!item.IsTree)
+                if (item.IsLink)
+                {
+                    outputZip.AddDirectoryByName(Path.Combine(item.TreeName, item.Path));
+                }
+                else if (!item.IsTree)
                 {
                     string blobReferenceName;
                     var model = browser.BrowseBlob(item.TreeName, item.Path, out blobReferenceName);

--- a/Bonobo.Git.Server/Models/RepositoryModels.cs
+++ b/Bonobo.Git.Server/Models/RepositoryModels.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Web;
 using System.ComponentModel.DataAnnotations;
 using Bonobo.Git.Server.App_GlobalResources;
 using LibGit2Sharp;
@@ -72,6 +70,7 @@ namespace Bonobo.Git.Server.Models
         [Display(ResourceType = typeof(Resources), Name = "Repository_Tree_Author")]
         public string Author { get; set; }
         public bool IsTree { get; set; }
+        public bool IsLink { get; set; }
         public string TreeName { get; set; }
         public bool IsImage { get; set; }
         public bool IsText { get; set; }

--- a/Bonobo.Git.Server/RepositoryBrowser.cs
+++ b/Bonobo.Git.Server/RepositoryBrowser.cs
@@ -88,6 +88,7 @@ namespace Bonobo.Git.Server
             {
                 Name = entry.Name,
                 IsTree = false,
+                IsLink = false,
                 CommitDate = commit.Author.When.LocalDateTime,
                 CommitMessage = commit.Message,
                 Author = commit.Author.Name,
@@ -125,7 +126,7 @@ namespace Bonobo.Git.Server
         }
 
 
-        private IEnumerable<RepositoryTreeDetailModel> GetTreeModelsWithDetails(Commit commit, Tree tree, string referenceName)
+        private IEnumerable<RepositoryTreeDetailModel> GetTreeModelsWithDetails(Commit commit, IEnumerable<TreeEntry> tree, string referenceName)
         {
             var ancestors = _repository.Commits.QueryBy(new CommitFilter { Since = commit, SortBy = CommitSortStrategies.Topological | CommitSortStrategies.Reverse }).ToList();
             var entries = tree.ToList();
@@ -152,7 +153,7 @@ namespace Bonobo.Git.Server
             return result;
         }
 
-        private IEnumerable<RepositoryTreeDetailModel> GetTreeModels(Tree tree, string referenceName)
+        private IEnumerable<RepositoryTreeDetailModel> GetTreeModels(IEnumerable<TreeEntry> tree, string referenceName)
         {
             return tree.Select(i => CreateRepositoryDetailModel(i, null, referenceName)).ToList();
         }
@@ -166,6 +167,7 @@ namespace Bonobo.Git.Server
                 CommitMessage = ancestor != null ? ancestor.MessageShort : String.Empty,
                 Author = ancestor != null ? ancestor.Author.Name : String.Empty,
                 IsTree = entry.TargetType == TreeEntryTargetType.Tree,
+                IsLink = entry.TargetType == TreeEntryTargetType.GitLink,
                 TreeName = treeName,
                 Path = entry.Path.Replace('\\', '/'),
                 IsImage = FileDisplayHandler.IsImage(entry.Name),

--- a/Bonobo.Git.Server/Views/Repository/Tree.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Tree.cshtml
@@ -22,7 +22,16 @@
                 @foreach (var item in Model.Files)
 	            {
                     <tr>
-                        <td class="path">@Html.ActionLink((string)item.Name, item.IsTree ? "Tree" : "Blob", new { encodedName = PathEncoder.Encode(item.TreeName), encodedPath = PathEncoder.Encode(item.Path, allowSlash: true) }, new { @class = item.IsTree ? "directory" : item.IsImage ? "image" : "file" })</td>
+                        <td class="path">
+                            @if (item.IsLink)
+                            {
+                                <span class="directory">@item.Name</span>
+                            }
+                            else
+                            {
+                                @Html.ActionLink(item.Name, item.IsTree ? "Tree" : "Blob", new {encodedName = PathEncoder.Encode(item.TreeName), encodedPath = PathEncoder.Encode(item.Path, allowSlash: true)}, new {@class = item.IsTree ? "directory" : item.IsImage ? "image" : "file"})
+                            }
+                        </td>
                         <td class="message"></td>
                         <td class="date"></td>
                     </tr>


### PR DESCRIPTION
`GitLink` node was treated as Blob. 
From now, you can not click on a `GitLink` node in repo browser.
An empty directory is added for each `GitLink` node in the zip file.
Fix #120 maybe #119 and #109
