### PR TITLE
Update SQL in InitialCreateScript.cs

### DIFF
--- a/Bonobo.Git.Server/Data/Update/SqlServer/InitialCreateScript.cs
+++ b/Bonobo.Git.Server/Data/Update/SqlServer/InitialCreateScript.cs
@@ -9,7 +9,7 @@
                 return @"
                     IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Repository'))
                     BEGIN
-                        CREATE TABLE [Repository] (
+                        CREATE TABLE [dbo].[Repository] (
                             [Name] VarChar(255) Not Null,
                             [Description] VarChar(255) Null,
                             [Anonymous] Bit Not Null,
@@ -19,7 +19,7 @@
 
                     IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Role'))
                     BEGIN
-                        CREATE TABLE [Role] (
+                        CREATE TABLE [dbo].[Role] (
                             [Name] VarChar(255) Not Null,
                             [Description] VarChar(255) Null,
                             Constraint [PK_Role] Primary Key ([Name])
@@ -28,7 +28,7 @@
 
                     IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Team'))
                     BEGIN
-                        CREATE TABLE [Team] (
+                        CREATE TABLE [dbo].[Team] (
                             [Name] VarChar(255) Not Null,
                             [Description] VarChar(255) Null,
                             Constraint [PK_Team] Primary Key ([Name])
@@ -37,7 +37,7 @@
 
                     IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'User'))
                     BEGIN
-                        CREATE TABLE [User] (
+                        CREATE TABLE [dbo].[User] (
                             [Name] VarChar(255) Not Null,
                             [Surname] VarChar(255) Not Null,
                             [Username] VarChar(255) Not Null,
@@ -49,7 +49,7 @@
 
                     IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'TeamRepository_Permission'))
                     BEGIN
-                        CREATE TABLE [TeamRepository_Permission] (
+                        CREATE TABLE [dbo].[TeamRepository_Permission] (
                             [Team_Name] VarChar(255) Not Null,
                             [Repository_Name] VarChar(255) Not Null,
                             Constraint [UNQ_TeamRepository_Permission_1] Unique ([Team_Name], [Repository_Name]),
@@ -60,7 +60,7 @@
 
                     IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserRepository_Administrator'))
                     BEGIN
-                        CREATE TABLE [UserRepository_Administrator] (
+                        CREATE TABLE [dbo].[UserRepository_Administrator] (
                             [User_Username] VarChar(255) Not Null,
                             [Repository_Name] VarChar(255) Not Null,
                             Constraint [UNQ_UserRepository_Administrator_1] Unique ([User_Username], [Repository_Name]),
@@ -71,7 +71,7 @@
 
                     IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserRepository_Permission'))
                     BEGIN
-                        CREATE TABLE [UserRepository_Permission] (
+                        CREATE TABLE [dbo].[UserRepository_Permission] (
                             [User_Username] VarChar(255) Not Null,
                             [Repository_Name] VarChar(255) Not Null,
                             Constraint [UNQ_UserRepository_Permission_1] Unique ([User_Username], [Repository_Name]),
@@ -82,7 +82,7 @@
 
                     IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserRole_InRole'))
                     BEGIN
-                        CREATE TABLE [UserRole_InRole] (
+                        CREATE TABLE [dbo].[UserRole_InRole] (
                             [User_Username] VarChar(255) Not Null,
                             [Role_Name] VarChar(255) Not Null,
                             Constraint [UNQ_UserRole_InRole_1] Unique ([User_Username], [Role_Name]),
@@ -93,7 +93,7 @@
 
                     IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserTeam_Member'))
                     BEGIN
-                        CREATE TABLE [UserTeam_Member] (
+                        CREATE TABLE [dbo].[UserTeam_Member] (
                             [User_Username] VarChar(255) Not Null,
                             [Team_Name] VarChar(255) Not Null,
                             Constraint [UNQ_UserTeam_Member_1] Unique ([User_Username], [Team_Name]),


### PR DESCRIPTION
I ran into a problem when installing to a SQL server instance.  I found that table names were created as [MYSERVICEACCOUNTNAME].[TableName] rather than [dbo].[TableName].  I'm proposing that adding [dbo]. before each table name in this script will create the correct table names.
