### PR TITLE
Updated to libgit2sharp 0.18.1.0

### DIFF
--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -86,9 +86,9 @@
     <Reference Include="Ionic.Zip">
       <HintPath>..\packages\DotNetZip.1.9.2\lib\net20\Ionic.Zip.dll</HintPath>
     </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.16.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="LibGit2Sharp, Version=0.18.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\LibGit2Sharp.0.16.0.0\lib\net35\LibGit2Sharp.dll</HintPath>
+      <HintPath>..\packages\LibGit2Sharp.0.18.1.0\lib\net40\LibGit2Sharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Practices.Unity, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -606,9 +606,13 @@
     <PreBuildEvent>
 if not exist "$(TargetDir)NativeBinaries" md "$(TargetDir)NativeBinaries"
 if not exist "$(TargetDir)NativeBinaries\x86" md "$(TargetDir)NativeBinaries\x86"
-xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.16.0.0\lib\net35\NativeBinaries\x86\*.*" "$(TargetDir)NativeBinaries\x86"
+xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\x86\*.*" "$(TargetDir)NativeBinaries\x86"
 if not exist "$(TargetDir)NativeBinaries\amd64" md "$(TargetDir)NativeBinaries\amd64"
-xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.16.0.0\lib\net35\NativeBinaries\amd64\*.*" "$(TargetDir)NativeBinaries\amd64"</PreBuildEvent>
+xcopy /s /y /d "$(SolutionDir)packages\LibGit2Sharp.0.18.1.0\lib\net40\NativeBinaries\amd64\*.*" "$(TargetDir)NativeBinaries\amd64"</PreBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Bonobo.Git.Server/Controllers/RepositoryController.cs
+++ b/Bonobo.Git.Server/Controllers/RepositoryController.cs
@@ -401,7 +401,14 @@ namespace Bonobo.Git.Server.Controllers
                     if (!Directory.Exists(targetRepositoryPath))
                     {
                         string sourceRepositoryPath = Path.Combine(UserConfiguration.Current.Repositories, id);
-                        LibGit2Sharp.Repository.Clone(sourceRepositoryPath, targetRepositoryPath, true, false);
+                        
+                        LibGit2Sharp.CloneOptions options = new LibGit2Sharp.CloneOptions()
+                            {
+                                IsBare = true,
+                                Checkout = false
+                            };
+
+                        LibGit2Sharp.Repository.Clone(sourceRepositoryPath, targetRepositoryPath, options);
                         TempData["CloneSuccess"] = true;
                         return RedirectToAction("Index");
                     }

--- a/Bonobo.Git.Server/packages.config
+++ b/Bonobo.Git.Server/packages.config
@@ -3,7 +3,7 @@
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
   <package id="DotNetZip" version="1.9.2" targetFramework="net45" />
   <package id="EntityFramework" version="5.0.0" targetFramework="net40" />
-  <package id="LibGit2Sharp" version="0.16.0.0" targetFramework="net45" />
+  <package id="LibGit2Sharp" version="0.18.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.2" targetFramework="net45" />


### PR DESCRIPTION
Hi,

Thanks for a great tool :+1: 

Due to that I'm running your server on a webserver at unoeuro I had a problem creating a new repository.

I tracked it down to something wrong with libgit2 and created a thread here https://github.com/libgit2/libgit2/issues/2486

But in the meantime I updated all the libs to see if that helped, but unfortunately it didn't - but I might as well share the update.

I tried to run the test, but two of them are failing 

``` C#
[TestMethod]
        public void HandlesCshtmlExtension()
        {
            Assert.AreEqual(PathEncoder.Encode("index.cshtml"), "index.cshtml.view");
            Assert.AreEqual(PathEncoder.Decode("index.cshtml.view"), "index.cshtml");
        }
```

and Mysysintegrationtest - due to a lot of local paths?

Hope you can use it,

Lars Glud
