### PR TITLE
Add Active Directory group / Team synchronization

### DIFF
--- a/Bonobo.Git.Server/Controllers/TeamController.cs
+++ b/Bonobo.Git.Server/Controllers/TeamController.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Web;
 using System.Web.Mvc;
 using Microsoft.Practices.Unity;
 using Bonobo.Git.Server.Data;
@@ -31,7 +30,7 @@ namespace Bonobo.Git.Server.Controllers
         {
             if (!String.IsNullOrEmpty(id))
             {
-                var model = ConvertTeamModel(TeamRepository.GetTeam(id));
+                var model = ConvertTeamModel(TeamRepository.GetTeam(UsernameUrl.Decode(id)));
                 PopulateViewData();
                 return View(model);
             }
@@ -90,7 +89,7 @@ namespace Bonobo.Git.Server.Controllers
         {
             if (!String.IsNullOrEmpty(id))
             {
-                return View(new TeamDetailModel { Name = id });
+                return View(new TeamDetailModel { Name = UsernameUrl.Decode(id) });
             }
 
             return RedirectToAction("Index");
@@ -114,7 +113,7 @@ namespace Bonobo.Git.Server.Controllers
         {
             if (!String.IsNullOrEmpty(id))
             {
-                return View(ConvertTeamModel(TeamRepository.GetTeam(id)));
+                return View(ConvertTeamModel(TeamRepository.GetTeam(UsernameUrl.Decode(id))));
             }
             return View();
         }

--- a/Bonobo.Git.Server/Data/EFTeamRepository.cs
+++ b/Bonobo.Git.Server/Data/EFTeamRepository.cs
@@ -129,5 +129,26 @@ namespace Bonobo.Git.Server.Data
                 team.Users.Add(item);
             }
         }
+
+        public void UpdateUserTeams(string userName, List<string> newTeams)
+        {
+            if (string.IsNullOrEmpty(userName)) throw new ArgumentException("userName");
+            if (newTeams == null) throw new ArgumentException("newTeams");
+
+            using (var db = new BonoboGitServerContext())
+            {
+                var user = db.Users.FirstOrDefault(u => u.Username == userName.ToLower());
+                if (user != null)
+                {
+                    user.Teams.Clear();
+                    var teams = db.Teams.Where(t => newTeams.Contains(t.Name));
+                    foreach (var team in teams)
+                    {
+                        user.Teams.Add(team);
+                    }
+                    db.SaveChanges();
+                }
+            }
+        }
     }
 }

--- a/Bonobo.Git.Server/Data/ITeamRepository.cs
+++ b/Bonobo.Git.Server/Data/ITeamRepository.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
+﻿using System.Collections.Generic;
 using Bonobo.Git.Server.Models;
 
 namespace Bonobo.Git.Server.Data
@@ -14,5 +11,6 @@ namespace Bonobo.Git.Server.Data
         void Delete(string name);
         bool Create(TeamModel team);
         void Update(TeamModel team);
+        void UpdateUserTeams(string userName, List<string> newTeams);
     }
 }

--- a/Bonobo.Git.Server/Views/Team/Detail.cshtml
+++ b/Bonobo.Git.Server/Views/Team/Detail.cshtml
@@ -44,8 +44,8 @@ else
                 <a class="pure-button" href="@Url.Action("Index")"><i class="fa fa-long-arrow-left"></i> @Resources.Team_Detail_Back</a>
                 @if (User.IsInRole(Definitions.Roles.Administrator))
                 {
-                    <a class="pure-button" href="@Url.Action("Edit", new { id = Model.Name })"><i class="fa fa-pencil-square-o"></i> @Resources.Team_Detail_Edit</a>
-                    <a class="pure-button" href="@Url.Action("Delete", new { id = Model.Name })"><i class="fa fa-trash-o"></i> @Resources.Team_Detail_Delete</a>
+                    <a class="pure-button" href="@Url.Action("Edit", new { id = UsernameUrl.Encode(Model.Name) })"><i class="fa fa-pencil-square-o"></i> @Resources.Team_Detail_Edit</a>
+                    <a class="pure-button" href="@Url.Action("Delete", new { id = UsernameUrl.Encode(Model.Name) })"><i class="fa fa-trash-o"></i> @Resources.Team_Detail_Delete</a>
                 }
             </div>
 

--- a/Bonobo.Git.Server/Views/Team/Index.cshtml
+++ b/Bonobo.Git.Server/Views/Team/Index.cshtml
@@ -34,10 +34,10 @@
     @grid.GetHtml(
         tableStyle: "pure-table teams",
         columns: grid.Columns(
-            grid.Column(header: typeof(TeamDetailModel).GetDisplayValue("Name"), format: (item) => Html.ActionLink((string)item.Name, "Detail", new { id = item.Name }, new { @class = "detail" })),
+            grid.Column(header: typeof(TeamDetailModel).GetDisplayValue("Name"), format: (item) => Html.ActionLink((string)item.Name, "Detail", new { id = UsernameUrl.Encode(item.Name) }, new { @class = "detail" })),
             grid.Column("Description", typeof(TeamDetailModel).GetDisplayValue("Description"), format: (item) => item.Description != null && ((string)item.Description).Length > 100 ? ((string)item.Description).Substring(0, 100) + " (...) " : item.Description),
-            grid.Column(format: (item) => Html.ActionLink(" ", "Edit", new { id = item.Name }, new { @class = "edit", title = Resources.Grid_Edit }), style: "action"),
-            grid.Column(format: (item) => Html.ActionLink(" ", "Delete", new { id = item.Name }, new { @class = "delete", title = Resources.Grid_Delete }), style: "action")
+            grid.Column(format: (item) => Html.ActionLink(" ", "Edit", new { id = UsernameUrl.Encode(item.Name) }, new { @class = "edit", title = Resources.Grid_Edit }), style: "action"),
+            grid.Column(format: (item) => Html.ActionLink(" ", "Delete", new { id = UsernameUrl.Encode(item.Name) }, new { @class = "delete", title = Resources.Grid_Delete }), style: "action")
         )
     )
 </div>

--- a/Bonobo.Git.Server/WindowsIdentityImporter.cs
+++ b/Bonobo.Git.Server/WindowsIdentityImporter.cs
@@ -1,4 +1,5 @@
-﻿using Bonobo.Git.Server.Security;
+﻿using Bonobo.Git.Server.Data;
+using Bonobo.Git.Server.Security;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
@@ -25,15 +26,17 @@ namespace Bonobo.Git.Server
             }
         }
 
-        private static void Import(IIdentity identity)
+        private static void Import(WindowsIdentity identity)
         {
             var service = new EFMembershipService();
             if (service.GetUser(identity.Name) != null)
             {
+                RefreshTeams(identity);
                 return;
             }
 
             service.CreateUser(identity.Name, "imported", identity.Name, "None", "None");
+            RefreshTeams(identity);
 
             if (
                 !String.Equals(ConfigurationManager.AppSettings["ShouldImportWindowsUserAsAdministrator"],
@@ -45,6 +48,53 @@ namespace Bonobo.Git.Server
 
             var roleProvider = new EFRoleProvider();
             roleProvider.AddUsersToRoles(new[] { identity.Name }, new[] { Definitions.Roles.Administrator });
+        }
+
+        private static void RefreshTeams(WindowsIdentity identity)
+        {
+            if (!String.Equals(ConfigurationManager.AppSettings["ActiveDirectoryIntegration"], "true", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return;
+            }
+
+            if (identity.Groups != null)
+            {
+                var groups = identity.Groups.Select(@group => @group.Translate(typeof (NTAccount)).ToString()).ToList();
+
+                var teamRepository = new EFTeamRepository();
+                var teams = teamRepository.GetAllTeams();
+
+                // Get current teams
+                var newTeams = teams.Where(t => t.Members.Contains(identity.Name)).Select(t => t.Name).ToList();
+                bool isChanged = false;
+
+                // Remove non matching group
+                foreach (var team in newTeams)
+                {
+                    var group = groups.SingleOrDefault(t => t == team);
+                    if (group == null)
+                    {
+                        newTeams.Remove(team);
+                        isChanged = true;
+                    }
+                }
+
+                // Insert new matching group
+                foreach (var group in groups)
+                {
+                    var team = teams.SingleOrDefault(t => t.Name == group);
+                    if (team != null && newTeams.All(t => t != identity.Name))
+                    {
+                        newTeams.Add(team.Name);
+                        isChanged = true;
+                    }
+                }
+
+                if (isChanged)
+                {
+                    teamRepository.UpdateUserTeams(identity.Name, newTeams);
+                }
+            }
         }
     }
 }

--- a/Bonobo.Git.Server/web.config
+++ b/Bonobo.Git.Server/web.config
@@ -21,7 +21,8 @@
     <add key="DefaultRepositoriesDirectory" value="~\App_Data\Repositories" />
     <add key="GitPath" value="~\App_Data\Git\git.exe" />
 
-    <add key="ShouldImportWindowsUserAsAdministrator" value="false" />   
+    <add key="ShouldImportWindowsUserAsAdministrator" value="false" />
+    <add key="ActiveDirectoryIntegration" value="false" />
   </appSettings>
   <connectionStrings>
     <!--<add name="BonoboGitServerContext" connectionString="Data Source=C:\inetpub\wwwroot\Bonobo.Git.Server\App_Data\Bonobo.Git.Server.db" providerName="System.Data.SQLite" />-->


### PR DESCRIPTION
Allows Team name with backslash (), I use the UsernameUrl.Encode that was already used for the username.

With Windows authentication, allows automatic synchronization of AD group with Bonobo Team.  The goal is to create teams with exact name as AD group and assign those teams to repositories.  Then network administrators can assign/remove an AD group to a user and he will automatically be synchronize in Bonobo when he connects.   That way, network admin won't have to support another credential system.
1. Configure Bonobo with Windows authentication.
2. Change the value of ActiveDirectoryIntegration in the web.config
3. Create a team with the format MYDOMAIN\Group-Name (domain and groups of current user can be obtains with this command "gpresult /V > result.txt"
4. Create a Repository and assign the appropriate team
5. Log in Bonobo web interface
