### PR TITLE
The commit detail template adjusted so the link creation detects an empt...

### DIFF
--- a/Bonobo.Git.Server/Views/Repository/_Commit.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/_Commit.cshtml
@@ -3,7 +3,7 @@
 <div class="commit pure-g">
     <div class="pure-u-4-5">
         <h4>@Model.Date.ToString()</h4>
-        <h2>@Html.ActionLink(Model.Message, "Commit", new { id = ViewBag.ID, commit = Model.ID }, new { title = Model.Message})</h2>
+        <h2>@Html.ActionLink(string.IsNullOrEmpty(Model.Message) ? "(null)" : Model.Message, "Commit", new { id = ViewBag.ID, commit = Model.ID }, new { title = string.IsNullOrEmpty(Model.Message) ? "(null)" : Model.Message })</h2>
     </div>
     <div class="pure-u-1-5 metadata">
         <h4>@Model.Author</h4>


### PR DESCRIPTION
This is fix of the template for #144. The root cause was actually an empty message. When such commit is rendered the link title renders as '(null)'.
