### PR TITLE
Made commit details parsing more robust for ReceivePackHook

### DIFF
--- a/Bonobo.Git.Server/Git/GitService/ReceivePackHook/ReceivePackParser.cs
+++ b/Bonobo.Git.Server/Git/GitService/ReceivePackHook/ReceivePackParser.cs
@@ -309,7 +309,7 @@ namespace Bonobo.Git.Server.Git.GitService.ReceivePackHook
             var timestampComponents = timestampString.Split(' ');
 
             // Start with epoch in UTC, add the timestamp seconds.
-            var timestamp = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var timestamp = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
             timestamp = timestamp.AddSeconds(long.Parse(timestampComponents[0]));
 
             return new ReceivePackCommitSignature(name, email, timestamp);


### PR DESCRIPTION
The initial implementation assumed that space was a valid token to use
for parsing the author/committer signature.  In practice this doesn't
work as the name field can contain spaces.

Further, the timestamp field sometimes contains an offset that allows
the local time to be calculated, making it harder to just find the
timestamp value in the array of tokens.

This change parses the tokens sequentially, first looking for the type
token and then passing the rest of the string as data for further
processing.

Signature parsing now uses the email address as the anchor for the
parser, looking for '<' and '>' first and basing the rest of the parsing
on that.  This should be a bit more robust to variations within the name
and timestamp fields.

Tested using the failing string by stepping through the debugging and
validating that all tokens were parsed as expected.
