### PR TITLE
Push auditing can be turned off through web.config.

### DIFF
--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -185,6 +185,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions\SignatureExtensions.cs" />
+    <Compile Include="Configuration\AppSettings.cs" />
     <Compile Include="Git\GitService\GitServiceResultParser.cs" />
     <Compile Include="Git\GitService\ReceivePackHook\Durability\AutoCreateMissingRecoveryDirectories.cs" />
     <Compile Include="Git\GitService\ReceivePackHook\Durability\OneFolderRecoveryFilePathBuilder.cs" />

--- a/Bonobo.Git.Server/Configuration/AppSettings.cs
+++ b/Bonobo.Git.Server/Configuration/AppSettings.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Web;
+
+namespace Bonobo.Git.Server.Configuration
+{
+    public static class AppSettings
+    {
+        public static bool IsPushAuditEnabled
+        {
+            get
+            {
+                return bool.Parse(ConfigurationManager.AppSettings["IsPushAuditEnabled"] ?? "false");
+            }
+        }
+    }
+}

--- a/Bonobo.Git.Server/Views/Repository/Detail.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Detail.cshtml
@@ -43,6 +43,7 @@
                     @Resources.Repository_Detail_No
                 }
             </div>
+            @if (AppSettings.IsPushAuditEnabled) {
             <div class="pure-control-group">
                 @Html.LabelFor(m => m.AuditPushUser)
                 @if (Model.AuditPushUser)
@@ -54,6 +55,7 @@
                     @Resources.Repository_Detail_No
                 }
             </div>
+            }
             <div class="pure-control-group">
                 @Html.LabelFor(m => m.Users)
                 @for (int i = 0; i < Model.Users.Length; i++)

--- a/Bonobo.Git.Server/Views/Repository/Edit.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Edit.cshtml
@@ -35,11 +35,13 @@ else
                 @Html.CheckBoxFor(m => m.AllowAnonymous)
                 <i class="fa fa-info-circle" title="@Resources.Repository_AllowAnonymousHint"></i>
             </div>
+            @if (AppSettings.IsPushAuditEnabled) { 
             <div class="pure-control-group">
                 @Html.LabelFor(m => m.AuditPushUser)
                 @Html.CheckBoxFor(m => m.AuditPushUser)
                 <i class="fa fa-info-circle" title="@Resources.Repository_AuditPushUserHint"></i>
             </div>
+            }
             <div class="pure-control-group checkboxlist">
                 @Html.LabelFor(m => m.Users)
                 @{


### PR DESCRIPTION
Adds ability to turns off audit pushing and git pack parsing through web.config. Set up to be off by default.
PR relates to #176
