### PR TITLE
Convert tabs to spaces in blob and commit views. Issue #186

### DIFF
--- a/Bonobo.Git.Server/Views/Repository/Blob.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Blob.cshtml
@@ -39,5 +39,5 @@
 
 @section scripts 
 {
-    <script>hljs.initHighlightingOnLoad();</script>
+    <script>hljs.configure({tabReplace:'    '});hljs.initHighlightingOnLoad();</script>
 }

--- a/Bonobo.Git.Server/Views/Repository/Commit.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Commit.cshtml
@@ -75,5 +75,5 @@
 
 @section scripts
 {
-    <script>hljs.initHighlightingOnLoad();</script>
+    <script>hljs.configure({tabReplace:'    '});hljs.initHighlightingOnLoad();</script>
 }


### PR DESCRIPTION
Let `hljs` convert tabs to spaces (four spaces per default). Fixes issue #186 
