### PR TITLE
Wrapped group identity translation in try/catch and filtered out null tr...

### DIFF
--- a/Bonobo.Git.Server/WindowsIdentityImporter.cs
+++ b/Bonobo.Git.Server/WindowsIdentityImporter.cs
@@ -64,10 +64,13 @@ namespace Bonobo.Git.Server
                     IdentityReference translated = null;
                     try
                     {
-                        translated = @group.Translate(typeof(NTAccount));
+                        if (@group != null)
+                        {
+                            translated = @group.Translate(typeof(NTAccount));
+                        }
                     }
 
-                    catch { }
+                    catch (System.Security.Principal.IdentityNotMappedException) { }
 
                     return translated == null ? null : translated.ToString();
                 })

--- a/Bonobo.Git.Server/WindowsIdentityImporter.cs
+++ b/Bonobo.Git.Server/WindowsIdentityImporter.cs
@@ -59,7 +59,20 @@ namespace Bonobo.Git.Server
 
             if (identity.Groups != null)
             {
-                var groups = identity.Groups.Select(@group => @group.Translate(typeof (NTAccount)).ToString()).ToList();
+                var groups = identity.Groups.Select(@group =>
+                {
+                    IdentityReference translated = null;
+                    try
+                    {
+                        translated = @group.Translate(typeof(NTAccount));
+                    }
+
+                    catch { }
+
+                    return translated == null ? null : translated.ToString();
+                })
+                .Where(s => string.IsNullOrWhiteSpace(s) == false)
+                .ToList();
 
                 var teamRepository = new EFTeamRepository();
                 var teams = teamRepository.GetAllTeams();


### PR DESCRIPTION
...anslations

Some group identities are not translatable and throws an exception, "System.Security.Principal.IdentityNotMappedException: Some or all identity references could not be translated."

I don't think there is a way to detect if an identity is translatable before attempting it, but we have this issue in our domain. I've run into this error before and I think the only thing that can be done is wrap the translation in a try/catch and eat the exception.