### PR TITLE
Feature: Commit messages like in github

### DIFF
--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -204,6 +204,8 @@
     <Compile Include="Git\GitService\ReceivePackHook\ReceivePackCommitSignature.cs" />
     <Compile Include="Git\GitService\ReplicatingStream.cs" />
     <Compile Include="Helpers\MembershipHelper.cs" />
+    <Compile Include="Helpers\RepositoryCommitModelHelpers.cs" />
+    <Compile Include="Models\RepositoryCommitTitle.cs" />
     <Compile Include="UnityDecoratorBuildStrategy.cs" />
     <Compile Include="UnityDecoratorContainerExtension.cs" />
     <Compile Include="Git\ConfigurationBasedRepositoryLocator.cs" />

--- a/Bonobo.Git.Server/Content/Site.css
+++ b/Bonobo.Git.Server/Content/Site.css
@@ -177,24 +177,6 @@ nav.branches ul li:hover ul li { float: none; }
         font-size: 0.7em;
     }
 
-.opacity-helper {
-    display: block;
-    height: 30px;
-    position: absolute;
-    right: 73px;
-    top: 5px;
-    width: 36px;
-    z-index: 10;
-    background: -moz-linear-gradient(left, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 54%);
-    background: -webkit-gradient(linear, left top, right top, color-stop(0%,rgba(255,255,255,0)), color-stop(54%,rgba(255,255,255,1)));
-    background: -webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 54%);
-    background: -o-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 54%);
-    background: -ms-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 54%);
-    background: linear-gradient(to right, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 54%);
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ffffff',GradientType=1 );
-}
-
-
 .more-commit-info-toggler {
     background-color: silver;
     border: 1px solid #a39e9e;

--- a/Bonobo.Git.Server/Content/Site.css
+++ b/Bonobo.Git.Server/Content/Site.css
@@ -153,5 +153,28 @@ nav.branches ul li:hover ul li { float: none; }
 .Commit .diff h3 { margin-top: 1.5em; }
 
 .commit .notes p { font-size: 0.7em; }
-.commit h2{ margin-bottom: 0 }
+.commit h2{ margin-bottom: 0; position:relative; }
 .commit .commitdate { font-size: 0.7em}
+
+.opacity-helper {
+    display: block;
+    height: 30px;
+    position: absolute;
+    right: -1px;
+    top: 5px;
+    width: 74px;
+    z-index: 10;
+
+    background: -moz-linear-gradient(left, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 54%);
+    background: -webkit-gradient(linear, left top, right top, color-stop(0%,rgba(255,255,255,0)), color-stop(54%,rgba(255,255,255,1)));
+    background: -webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 54%);
+    background: -o-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 54%);
+    background: -ms-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 54%);
+    background: linear-gradient(to right, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 54%);
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ffffff',GradientType=1 );
+}
+
+.pure-u-2-5.metadata div {
+    z-index:11;
+    position:relative;
+}

--- a/Bonobo.Git.Server/Content/Site.css
+++ b/Bonobo.Git.Server/Content/Site.css
@@ -156,15 +156,35 @@ nav.branches ul li:hover ul li { float: none; }
 .commit h2{ margin-bottom: 0; position:relative; }
 .commit .commitdate { font-size: 0.7em}
 
+.pure-u-2-5.metadata div {
+    z-index:11;
+    position:relative;
+}
+
+.commit h2 {
+        margin-bottom: 0;
+        position: relative;
+    }
+
+        .commit h2 a.commit-url {
+            display: inline-block;
+            max-width: 90%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+    .commit .commitdate {
+        font-size: 0.7em;
+    }
+
 .opacity-helper {
     display: block;
     height: 30px;
     position: absolute;
-    right: -1px;
+    right: 73px;
     top: 5px;
-    width: 74px;
+    width: 36px;
     z-index: 10;
-
     background: -moz-linear-gradient(left, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 54%);
     background: -webkit-gradient(linear, left top, right top, color-stop(0%,rgba(255,255,255,0)), color-stop(54%,rgba(255,255,255,1)));
     background: -webkit-linear-gradient(left, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 54%);
@@ -174,7 +194,19 @@ nav.branches ul li:hover ul li { float: none; }
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#ffffff',GradientType=1 );
 }
 
-.pure-u-2-5.metadata div {
-    z-index:11;
-    position:relative;
+
+.more-commit-info-toggler {
+    background-color: silver;
+    border: 1px solid #a39e9e;
+    border-radius: 1px;
+    color: #827a7a;
+    display: inline-block;
+    font-size: 14px;
+    font-weight: bold;
+    height: 12px;
+    line-height: 6px;
+    padding: 0 6px 1px;
+    position: relative;
+    top: -9px;
+    vertical-align: middle;
 }

--- a/Bonobo.Git.Server/Helpers/RepositoryCommitModelHelpers.cs
+++ b/Bonobo.Git.Server/Helpers/RepositoryCommitModelHelpers.cs
@@ -1,0 +1,85 @@
+﻿using Bonobo.Git.Server.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Mvc;
+
+namespace Bonobo.Git.Server.Helpers
+{
+    public static class RepositoryCommitModelHelpers
+    {
+        /// <summary>
+        /// Create message
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        internal static RepositoryCommitTitleModel MakeCommitMessage(string message)
+        {
+            return BreakLine(message, 25);
+        }
+
+        /// <summary>
+        /// Create message
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="messageLengthLimit"></param>
+        /// <returns></returns>
+        internal static RepositoryCommitTitleModel MakeCommitMessage(string message, int messageLengthLimit)
+        {
+            return BreakLine(message, messageLengthLimit);
+        }
+
+        /// <summary>
+        /// Split a string to blocks by word
+        /// </summary>
+        /// <param name="title"></param>
+        /// <param name="blockLength"></param>
+        /// <returns></returns>
+        private static RepositoryCommitTitleModel BreakLine(string title, int blockLength)
+        {
+            IEnumerable<string> words = title.Split(' ')
+                .Select(el => el.Trim())
+                .Where(el => !string.IsNullOrEmpty(el)).ToArray();
+
+            List<string> message = new List<string>();
+            List<string> preBlock = new List<string>();
+            bool addToPreMessage = false;
+
+            int currentLen = 0;
+            int wordsLength = words.Count();
+
+            foreach (string word in words)
+            {
+                if (addToPreMessage)
+                {
+                    preBlock.Add(word);
+                }
+                else
+                {
+                    message.Add(word);
+                }
+                currentLen += word.Length;
+
+                if (currentLen >= blockLength)
+                {
+                    currentLen = 0;
+                    addToPreMessage = true;
+                }
+            }
+
+            var messageString = string.Join(" ", message.ToArray()).Trim();
+            var preBlockString = string.Join(" ", preBlock.ToArray()).Trim();
+
+            if (preBlockString.Length > 0)
+            {
+                messageString += "&hellip;";
+                preBlockString = "&hellip;" + preBlockString;
+            }
+
+            return new RepositoryCommitTitleModel
+            {
+                ShortTitle = MvcHtmlString.Create(messageString).ToHtmlString(),
+                ExtraTitle = MvcHtmlString.Create(preBlockString).ToHtmlString()
+            };
+        }
+    }
+}

--- a/Bonobo.Git.Server/Models/RepositoryCommitTitle.cs
+++ b/Bonobo.Git.Server/Models/RepositoryCommitTitle.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Bonobo.Git.Server.Models
+{
+    public class RepositoryCommitTitleModel
+    {
+        public string ShortTitle { get; set; }
+
+        public string ExtraTitle { get; set; }
+    }
+}

--- a/Bonobo.Git.Server/RepositoryBrowser.cs
+++ b/Bonobo.Git.Server/RepositoryBrowser.cs
@@ -6,6 +6,7 @@ using Bonobo.Git.Server.Models;
 using Bonobo.Git.Server.Extensions;
 using LibGit2Sharp;
 using System.IO;
+using Bonobo.Git.Server.Helpers;
 
 namespace Bonobo.Git.Server
 {
@@ -235,7 +236,7 @@ namespace Bonobo.Git.Server
             {
                 Name = entry.Name,
                 CommitDate = ancestor != null ? ancestor.Author.When.LocalDateTime : default(DateTime?),
-                CommitMessage = ancestor != null ? ancestor.MessageShort : String.Empty,
+                CommitMessage = ancestor != null ? RepositoryCommitModelHelpers.MakeCommitMessage(ancestor.Message, 50).ShortTitle : String.Empty,
                 Author = ancestor != null ? ancestor.Author.Name : String.Empty,
                 IsTree = entry.TargetType == TreeEntryTargetType.Tree,
                 IsLink = entry.TargetType == TreeEntryTargetType.GitLink,
@@ -280,6 +281,8 @@ namespace Bonobo.Git.Server
             if (tags != null && tags.Any())
                 tagsString = tags.Select(o => o.Name).Aggregate((o, p) => o + " " + p);
 
+            var shortMessageDetails = RepositoryCommitModelHelpers.MakeCommitMessage(commit.Message);
+
             var model = new RepositoryCommitModel
             {
                 Author = commit.Author.Name,
@@ -287,8 +290,8 @@ namespace Bonobo.Git.Server
                 AuthorAvatar = commit.Author.GetAvatar(),
                 Date = commit.Author.When.LocalDateTime,
                 ID = commit.Sha,
-                Message = commit.Message,
-                MessageShort = commit.MessageShort,
+                Message = shortMessageDetails.ShortTitle,
+                MessageShort = shortMessageDetails.ExtraTitle,
                 TreeID = commit.Tree.Sha,
                 Parents = commit.Parents.Select(i => i.Sha).ToArray(),
                 TagName = tagsString,

--- a/Bonobo.Git.Server/RepositoryBrowser.cs
+++ b/Bonobo.Git.Server/RepositoryBrowser.cs
@@ -232,11 +232,16 @@ namespace Bonobo.Git.Server
 
         private RepositoryTreeDetailModel CreateRepositoryDetailModel(TreeEntry entry, Commit ancestor, string treeName)
         {
+            var maximumMessageLength = 50; //FIXME Propbably in appSettings?
+            var originMessage = ancestor != null ? ancestor.Message : String.Empty;
+            var commitMessage = String.IsNullOrEmpty(originMessage)
+                ? RepositoryCommitModelHelpers.MakeCommitMessage(originMessage, maximumMessageLength).ShortTitle : String.Empty;
+
             return new RepositoryTreeDetailModel
             {
                 Name = entry.Name,
                 CommitDate = ancestor != null ? ancestor.Author.When.LocalDateTime : default(DateTime?),
-                CommitMessage = ancestor != null ? RepositoryCommitModelHelpers.MakeCommitMessage(ancestor.Message, 50).ShortTitle : String.Empty,
+                CommitMessage = commitMessage,
                 Author = ancestor != null ? ancestor.Author.Name : String.Empty,
                 IsTree = entry.TargetType == TreeEntryTargetType.Tree,
                 IsLink = entry.TargetType == TreeEntryTargetType.GitLink,

--- a/Bonobo.Git.Server/RepositoryBrowser.cs
+++ b/Bonobo.Git.Server/RepositoryBrowser.cs
@@ -234,7 +234,7 @@ namespace Bonobo.Git.Server
         {
             var maximumMessageLength = 50; //FIXME Propbably in appSettings?
             var originMessage = ancestor != null ? ancestor.Message : String.Empty;
-            var commitMessage = String.IsNullOrEmpty(originMessage)
+            var commitMessage = !String.IsNullOrEmpty(originMessage)
                 ? RepositoryCommitModelHelpers.MakeCommitMessage(originMessage, maximumMessageLength).ShortTitle : String.Empty;
 
             return new RepositoryTreeDetailModel
@@ -286,7 +286,7 @@ namespace Bonobo.Git.Server
             if (tags != null && tags.Any())
                 tagsString = tags.Select(o => o.Name).Aggregate((o, p) => o + " " + p);
 
-            var shortMessageDetails = RepositoryCommitModelHelpers.MakeCommitMessage(commit.Message);
+            var shortMessageDetails = RepositoryCommitModelHelpers.MakeCommitMessage(commit.Message, 30);
 
             var model = new RepositoryCommitModel
             {

--- a/Bonobo.Git.Server/Views/Repository/_Commit.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/_Commit.cshtml
@@ -2,15 +2,16 @@
 @using Bonobo.Git.Server.Extensions
 <div class="commit pure-g">
     <div class="pure-u-3-5">
-        <h2>@Html.ActionLink(Model.MessageShort, "Commit", new { id = ViewBag.ID, commit = Model.ID }, new { title = Model.Message })</h2>
+        <h2><a href="@Url.Action("Commit", new { id = ViewBag.ID, commit = Model.ID })">@Html.Raw(Model.Message)</a><span class="opacity-helper"></span></h2>
         <div class="commitdate">
             @Model.Date.ToString()
             @if (!string.IsNullOrEmpty(Model.TagName)){
                 <span class="tag">@Html.ActionLink(Model.TagName, "Commits", new { encodedName = PathEncoder.Encode(Model.TagName), encodedPath = String.Empty })</span>
             }
         </div>
-        @if (!ViewBag.ShowShortMessageOnly && Model.Message != Model.MessageShort){
-            <pre>@Model.Message.Replace(Model.MessageShort,"")</pre>
+        @if (/*!ViewBag.ShowShortMessageOnly && */Model.Message != Model.MessageShort)
+        {
+            <pre>@Html.Raw(Model.MessageShort)</pre>
         }
 
         <div class="notes">

--- a/Bonobo.Git.Server/Views/Repository/_Commit.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/_Commit.cshtml
@@ -2,16 +2,24 @@
 @using Bonobo.Git.Server.Extensions
 <div class="commit pure-g">
     <div class="pure-u-3-5">
-        <h2><a href="@Url.Action("Commit", new { id = ViewBag.ID, commit = Model.ID })">@Html.Raw(Model.Message)</a><span class="opacity-helper"></span></h2>
+        <h2>
+            <a class="commit-url" href="@Url.Action("Commit", new { id = ViewBag.ID, commit = Model.ID })">@Html.Raw(Model.Message)</a>
+            <span class="opacity-helper"></span>
+            @if (!string.IsNullOrEmpty(Model.MessageShort))
+            {
+                <a class="more-commit-info-toggler" onclick="$('#more@(Model.ID)').toggle();">&hellip;</a>
+            }
+        </h2>
+
         <div class="commitdate">
             @Model.Date.ToString()
             @if (!string.IsNullOrEmpty(Model.TagName)){
                 <span class="tag">@Html.ActionLink(Model.TagName, "Commits", new { encodedName = PathEncoder.Encode(Model.TagName), encodedPath = String.Empty })</span>
             }
         </div>
-        @if (/*!ViewBag.ShowShortMessageOnly && */Model.Message != Model.MessageShort)
+        @if (!string.IsNullOrEmpty(Model.MessageShort))
         {
-            <pre>@Html.Raw(Model.MessageShort)</pre>
+            <pre style="display:none;" id="more@(Model.ID)">@Html.Raw(Model.MessageShort)</pre>
         }
 
         <div class="notes">

--- a/Bonobo.Git.Server/Views/Repository/_Commit.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/_Commit.cshtml
@@ -4,7 +4,6 @@
     <div class="pure-u-3-5">
         <h2>
             <a class="commit-url" href="@Url.Action("Commit", new { id = ViewBag.ID, commit = Model.ID })">@Html.Raw(Model.Message)</a>
-            <span class="opacity-helper"></span>
             @if (!string.IsNullOrEmpty(Model.MessageShort))
             {
                 <a class="more-commit-info-toggler" onclick="$('#more@(Model.ID)').toggle();">&hellip;</a>


### PR DESCRIPTION
Hello!

I refactor commit messages, now they look like in github.
I have the trouble with storing splitted commit messages, i use for it properties Message and MessageShort. 
Any ideas for refactor, suggestions?

Screenshots:
Default state:
![screenshot_1](https://cloud.githubusercontent.com/assets/1185266/6406870/1dcfaf40-be60-11e4-9775-169d76ab53a4.png)
Expanded state:
![screenshot_2](https://cloud.githubusercontent.com/assets/1185266/6406876/2f17ba72-be60-11e4-9222-1fdc9ffe7c95.png)
