### PR TITLE
Proposed Fix for Bonobo Issue #166

### DIFF
--- a/Bonobo.Git.Server/Git/GitService/ExecutionOptions.cs
+++ b/Bonobo.Git.Server/Git/GitService/ExecutionOptions.cs
@@ -8,6 +8,7 @@ namespace Bonobo.Git.Server.Git.GitService
     public class ExecutionOptions
     {
         public bool AdvertiseRefs { get; set; }
+        public bool endStreamWithClose = false;
 
         public string ToCommandLineArgs()
         {

--- a/Bonobo.Git.Server/Git/GitService/GitServiceExecutor.cs
+++ b/Bonobo.Git.Server/Git/GitService/GitServiceExecutor.cs
@@ -56,7 +56,11 @@ namespace Bonobo.Git.Server.Git.GitService
             using (var process = Process.Start(info))
             {
                 inStream.CopyTo(process.StandardInput.BaseStream);
-                process.StandardInput.Write('\0');
+                if (options.endStreamWithClose) {
+                    process.StandardInput.Close();
+                } else {
+                    process.StandardInput.Write('\0');
+                }
 
                 process.StandardOutput.BaseStream.CopyTo(outStream);
                 process.WaitForExit();

--- a/Bonobo.Git.Server/Git/GitService/GitServiceExtensions.cs
+++ b/Bonobo.Git.Server/Git/GitService/GitServiceExtensions.cs
@@ -14,7 +14,7 @@ namespace Bonobo.Git.Server.Git.GitService
                 correlationId,
                 repositoryName,
                 "upload-pack",
-                new ExecutionOptions() { AdvertiseRefs = false },
+                new ExecutionOptions() { AdvertiseRefs = false, endStreamWithClose = true },
                 inStream,
                 outStream);
         }


### PR DESCRIPTION
In our project we need to be able to create shallow git clones and I have found, that this doesn't work due to Bonobo Issue #166.
As far as I can see, the proposed patch would fix the problem. I think, when using "upload-pack", git.exe does not recognise a null character as end of stream. I replaced "Write('\0')" with "Close" in that case and --depth=1 seems to work properly.

I am not quite sure, if Close would be generally the better solution than Write('\0'). To be on the safe side I replaces it in the case of "upload-pack" only.