### PR TITLE
Remove default port from repository URL

### DIFF
--- a/Bonobo.Git.Server/Views/Repository/Detail.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Detail.cshtml
@@ -7,7 +7,7 @@
                         ?? string.Format("{0}://{1}{2}{3}/", 
                                             Request.Url.Scheme, 
                                             Request.Url.Host, 
-                                            (Request.Url.Port == 80 ? "" : (":" + Request.Url.Port)),
+                                            (Request.Url.IsDefaultPort ? "" : (":" + Request.Url.Port)),
                                             Request.ApplicationPath == "/" ? "" : Request.ApplicationPath
                                         );
 }


### PR DESCRIPTION
Default port numbers should be removed from repository URL.
Current implementation only removes 80 port no matter of protocol used.
In case of HTTPS protocol 443 port should be removed as well.