### PR TITLE
Fix bug with edit/view non-domain users with enabled domain integration

### DIFF
--- a/Bonobo.Git.Server/UsernameUrl.cs
+++ b/Bonobo.Git.Server/UsernameUrl.cs
@@ -28,8 +28,8 @@ namespace Bonobo.Git.Server
         public static string Decode(string username)
         {
             var nameParts = username.Split('@');
-            if ( (nameParts.Count() == 2 && !_isEmailRegEx.IsMatch(username) ) ||
-                 String.Equals(ConfigurationManager.AppSettings["ActiveDirectoryIntegration"], "true", StringComparison.InvariantCultureIgnoreCase))
+            if ( (nameParts.Count() == 2) && (!_isEmailRegEx.IsMatch(username) ||
+                 (String.Equals(ConfigurationManager.AppSettings["ActiveDirectoryIntegration"], "true", StringComparison.InvariantCultureIgnoreCase))))
             {
                 return nameParts[1] + "\\" + nameParts[0];
             }


### PR DESCRIPTION
When fixing bug #262, I forgot about edit/view non-domain users with domain integration in Bonobo. Fixed.