### PR TITLE
Make authenticated user name accessible on push

### DIFF
--- a/Bonobo.Git.Server/Git/GitService/GitServiceExecutor.cs
+++ b/Bonobo.Git.Server/Git/GitService/GitServiceExecutor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using System.Web;
 
 namespace Bonobo.Git.Server.Git.GitService
 {
@@ -52,6 +53,7 @@ namespace Bonobo.Git.Server.Git.GitService
             };
 
             SetHomePath(info);
+            info.EnvironmentVariables.Add("AUTH_USER", HttpContext.Current.Request.ServerVariables["AUTH_USER"]);
 
             using (var process = Process.Start(info))
             {


### PR DESCRIPTION
As per issue #179, make the authenticated user name accessible via an
environment variable to allow for git hook validation of the user.

This was also my solution to #256, as I also had need of read-only permissions. By maintaining a list of users with write access, the pre-receive hook simply checks that the value of 'AUTH_USER' is in the list of users.