### PR TITLE
Fix blob previewing bug: #272

### DIFF
--- a/Bonobo.Git.Server/FileDisplayHandler.cs
+++ b/Bonobo.Git.Server/FileDisplayHandler.cs
@@ -12,6 +12,8 @@ namespace Bonobo.Git.Server
 {
     public static class FileDisplayHandler
     {
+        public const string NoBrush = "nohighlight";
+
         public static bool IsImage(string fileName)
         {
             return GetMimeType(fileName).Contains("image");
@@ -113,7 +115,7 @@ namespace Bonobo.Git.Server
                 case ".sql":
                     return "sql";
                 default:
-                    return "nohighlight";
+                    return NoBrush;
             }
         }
 
@@ -614,6 +616,8 @@ namespace Bonobo.Git.Server
 
             return null;
         }
+
+
 
         /// <summary>
         /// <para>Returns the human-readable file size for an arbitrary, 64-bit file size</para>

--- a/Bonobo.Git.Server/RepositoryBrowser.cs
+++ b/Bonobo.Git.Server/RepositoryBrowser.cs
@@ -129,23 +129,18 @@ namespace Bonobo.Git.Server
             model.Encoding = FileDisplayHandler.GetEncoding(model.Data);
             model.IsText = model.Text != null;
             model.IsMarkdown = model.IsText && Path.GetExtension(path).Equals(".md", StringComparison.OrdinalIgnoreCase);
+            model.TextBrush = FileDisplayHandler.GetBrush(path);
 
             // try to render as text file if the extension matches
-            if (FileDisplayHandler.GetBrush(path) != "plain")
+            if (model.TextBrush != FileDisplayHandler.NoBrush && model.IsText == false)
             {
                 model.IsText = true;
                 model.Encoding = Encoding.Default;
                 model.Text = new StreamReader(new MemoryStream(model.Data), model.Encoding, true).ReadToEnd();
             }
 
-            if (model.IsText)
-            {
-                model.TextBrush = FileDisplayHandler.GetBrush(path);
-            }
-            else
-            {
-                model.IsImage = FileDisplayHandler.IsImage(path);
-            }
+            //blobs can be images even when they are text files.(like svg, but it's not in out MIME table yet)
+            model.IsImage = FileDisplayHandler.IsImage(path);
 
             return model;
         }
@@ -325,7 +320,7 @@ namespace Bonobo.Git.Server
                     LinesAdded = patch.LinesAdded,
                     LinesDeleted = patch.LinesDeleted,
                     Patch = patch.Patch,
-                     
+
                 };
             });
 


### PR DESCRIPTION
Fix blob previewing bug #272 : 
1. incorrect text encoding when system default encoding differs from text file, 
2. all non-text files incorrectly be rendered as text file.
