### PR TITLE
allow app relative path for repositories

### DIFF
--- a/Bonobo.Git.Server/Configuration/UserConfiguration.cs
+++ b/Bonobo.Git.Server/Configuration/UserConfiguration.cs
@@ -10,9 +10,10 @@ namespace Bonobo.Git.Server.Configuration
 
     [XmlRootAttribute(ElementName = "Configuration", IsNullable = false)]
     public class UserConfiguration : ConfigurationEntry<UserConfiguration>
-    {      
+    {
         public bool AllowAnonymousPush { get; set; }
-        public string Repositories { get; set; }
+        [XmlElementAttribute(ElementName = "Repositories")]
+        public string RepositoryPath { get; set; }
         public bool AllowUserRepositoryCreation { get; set; }
         public bool AllowAnonymousRegistration { get; set; }
         public string DefaultLanguage { get; set; }
@@ -20,6 +21,16 @@ namespace Bonobo.Git.Server.Configuration
         public string SiteLogoUrl { get; set; }
         public string SiteFooterMessage { get; set; }
         public bool IsCommitAuthorAvatarVisible { get; set; }
+
+        public string Repositories
+        {
+            get
+            {
+                return Path.IsPathRooted(RepositoryPath)
+                       ? RepositoryPath
+                       : HttpContext.Current.Server.MapPath(RepositoryPath);
+            }
+        }
 
         public bool HasSiteFooterMessage
         {
@@ -47,16 +58,14 @@ namespace Bonobo.Git.Server.Configuration
             if (IsInitialized())
                 return;
 
-            Current.Repositories = Path.IsPathRooted(ConfigurationManager.AppSettings["DefaultRepositoriesDirectory"]) 
-                ? ConfigurationManager.AppSettings["DefaultRepositoriesDirectory"] 
-                : HttpContext.Current.Server.MapPath(ConfigurationManager.AppSettings["DefaultRepositoriesDirectory"]);
+            Current.RepositoryPath = ConfigurationManager.AppSettings["DefaultRepositoriesDirectory"];
             Current.Save();
         }
 
 
         private static bool IsInitialized()
         {
-            return !String.IsNullOrEmpty(Current.Repositories);
+            return !String.IsNullOrEmpty(Current.RepositoryPath);
         }
     }
 }

--- a/Bonobo.Git.Server/Controllers/SettingsController.cs
+++ b/Bonobo.Git.Server/Controllers/SettingsController.cs
@@ -21,7 +21,7 @@ namespace Bonobo.Git.Server.Controllers
             return View(new GlobalSettingsModel
             {
                 AllowAnonymousPush = UserConfiguration.Current.AllowAnonymousPush,
-                RepositoryPath = UserConfiguration.Current.Repositories,
+                RepositoryPath = UserConfiguration.Current.RepositoryPath,
                 AllowAnonymousRegistration = UserConfiguration.Current.AllowAnonymousRegistration,
                 AllowUserRepositoryCreation = UserConfiguration.Current.AllowUserRepositoryCreation,
                 DefaultLanguage = UserConfiguration.Current.DefaultLanguage,
@@ -40,10 +40,12 @@ namespace Bonobo.Git.Server.Controllers
             {
                 try
                 {
-                    if (Directory.Exists(model.RepositoryPath))
+                    if (Directory.Exists(Path.IsPathRooted(model.RepositoryPath)
+                                         ? model.RepositoryPath
+                                         : HttpContext.Server.MapPath(model.RepositoryPath)))
                     {
                         UserConfiguration.Current.AllowAnonymousPush = model.AllowAnonymousPush;
-                        UserConfiguration.Current.Repositories = model.RepositoryPath;
+                        UserConfiguration.Current.RepositoryPath = model.RepositoryPath;
                         UserConfiguration.Current.AllowAnonymousRegistration = model.AllowAnonymousRegistration;
                         UserConfiguration.Current.AllowUserRepositoryCreation = model.AllowUserRepositoryCreation;
                         UserConfiguration.Current.DefaultLanguage = model.DefaultLanguage;


### PR DESCRIPTION
allow user config to store app relative path, such as "~/App_Data/Repositories". Previously it will initialize the user config with default and then write the absolute path of "~/App_Data/Repositories" to user config, which is somehow not convenient when moving the web root folder.