### PR TITLE
View of text files

### DIFF
--- a/Bonobo.Git.Server/FileDisplayHandler.cs
+++ b/Bonobo.Git.Server/FileDisplayHandler.cs
@@ -595,7 +595,7 @@ namespace Bonobo.Git.Server
             ICharsetDetector cdet = new CharsetDetector();
             cdet.Feed(data, 0, data.Length);
             cdet.DataEnd();
-            if (cdet.Charset != null && cdet.Confidence > 0.5)
+            if (cdet.Charset != null && cdet.Confidence >= 0.5)
             {
                 if (cdet.Charset.ToLowerInvariant() == "big-5")
                 {


### PR DESCRIPTION
charset windows-1252 is just detected with 0.5 confidence.

Might also solve #307 if they are encoded above mentioned charset.