### PR TITLE
Update content reference to LibGit2Sharp

### DIFF
--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -471,8 +471,8 @@
     <Content Include="App_Data\note.txt" />
     <Content Include="App_Data\Repositories\note.txt" />
     <EmbeddedResource Include="App_GlobalResources\Resources.fr-FR.resx" />
-    <Content Include="bin\NativeBinaries\amd64\git2-90befde.dll" />
-    <Content Include="bin\NativeBinaries\x86\git2-90befde.dll" />
+    <Content Include="bin\NativeBinaries\amd64\git2-e0902fb.dll" />
+    <Content Include="bin\NativeBinaries\x86\git2-e0902fb.dll" />
     <Content Include="Content\components\font-awesome\css\font-awesome.min.css" />
     <Content Include="Content\components\font-awesome\fonts\fontawesome-webfont.eot" />
     <Content Include="Content\components\font-awesome\fonts\fontawesome-webfont.svg" />


### PR DESCRIPTION
Proposed fix for #317 

LibGitSharp v0.21.0.* contains git2-e0902fb.dll (see https://github.com/libgit2/libgit2sharp/commit/3b0f7e16c7a773076515409990964ae7c807d59f), commit https://github.com/jakubgarfield/Bonobo-Git-Server/commit/4f4a10b8e92a997771cc7892571f502b3b1aff17 made incorrect reference.