### PR TITLE
Initialize user configuration before registering dependency resolver

### DIFF
--- a/Bonobo.Git.Server/Global.asax.cs
+++ b/Bonobo.Git.Server/Global.asax.cs
@@ -69,10 +69,10 @@ namespace Bonobo.Git.Server
             AreaRegistration.RegisterAllAreas();
             BundleConfig.RegisterBundles(BundleTable.Bundles);
             RouteConfig.RegisterRoutes(RouteTable.Routes);
+            UserConfiguration.Initialize();
             RegisterDependencyResolver();
 
             new AutomaticUpdater().Run();
-            UserConfiguration.Initialize();
             new RepositorySynchronizer().Run();
         }
 


### PR DESCRIPTION
Calling RegisterDependencyResolver() before initializing UserConfiguration throws a NullReferenceException in case of a clean install where no config.xml is present in AppData.  
Creating GitServiceExecutorParams in RegisterDependencyResolver uses UserConfiguration.Current.Repositories where the getter tries to use the RepositoryPath member.  This is null prior to initialization.