### PR TITLE
Updated EFRepositoryRepository to handle null username like the ADRepositoryRepository

### DIFF
--- a/Bonobo.Git.Server/Data/EFRepositoryRepository.cs
+++ b/Bonobo.Git.Server/Data/EFRepositoryRepository.cs
@@ -43,13 +43,14 @@ namespace Bonobo.Git.Server.Data
 
         public IList<RepositoryModel> GetPermittedRepositories(string username, string[] teams)
         {
-            if (username == null) throw new ArgumentException("username");
+            if (!string.IsNullOrEmpty(username))
+                username = username.ToLowerInvariant();
 
-            username = username.ToLowerInvariant();
-            return GetAllRepositories().Where(i => i.Administrators.Contains(username)
-                || i.Users.Contains(username)
-                || i.Teams.FirstOrDefault(t => teams.Contains(t)) != null
-                || i.AnonymousAccess).ToList();
+            return GetAllRepositories().Where( i => 
+                (String.IsNullOrEmpty(username) ? false : i.Users.Contains(username)) ||
+                (String.IsNullOrEmpty(username) ? false : i.Administrators.Contains(username)) ||
+                i.Teams.FirstOrDefault(t => teams.Contains(t)) != null ||
+                i.AnonymousAccess).ToList();
         }
 
         public IList<RepositoryModel> GetAdministratedRepositories(string username)


### PR DESCRIPTION
However I don't think the method in ADRepositoryRepository works as intended, as I had to add additional parentheses when checking for null username.

This should solve #331 assuming the demo is using local database with EF?
@jakubgarfield @Ollienator