### PR TITLE
CookieAuthentication login issue fixed

### DIFF
--- a/Bonobo.Git.Server/Security/CookieAuthenticationProvider.cs
+++ b/Bonobo.Git.Server/Security/CookieAuthenticationProvider.cs
@@ -45,7 +45,7 @@ namespace Bonobo.Git.Server.Security
             HttpContext.Current.GetOwinContext().Authentication.SignIn(identity);
             if (!String.IsNullOrEmpty(returnUrl))
             {
-                HttpContext.Current.Response.Redirect(returnUrl);
+                HttpContext.Current.Response.Redirect(returnUrl, false);
             }
         }
 


### PR DESCRIPTION
There was no way to login with CookieAuthentication because auth cookie hasn't been set. So there was always redirect to login page.

Why?
Unlike FormsAuthentication, which actually sets the cookies when you write your authentication code, AuthenticationManager creates an AuthenticationResponseGrant or AuthenticationResponseRevoke object.

So the authentication cookies are not set at the time of calling authentication.SignIn(authProperties, claimsIdentity); They're called later, so ending the response using Response.Redirect will kill the thread before the cookies get added onto the response object. By changing the endResponse parameter to false, the cookies get applied to the response object as expected.