### PR TITLE
Fixed #333 and properly receiving appropriate repos when browsing teams.

### DIFF
--- a/Bonobo.Git.Server/Data/ADRepositoryRepository.cs
+++ b/Bonobo.Git.Server/Data/ADRepositoryRepository.cs
@@ -37,7 +37,10 @@ namespace Bonobo.Git.Server.Data
 
         public IList<RepositoryModel> GetPermittedRepositories(string username, string[] userTeams)
         {
-            return ADBackend.Instance.Repositories.Where(x => String.IsNullOrEmpty(username) ? false : x.Users.Contains(username, StringComparer.OrdinalIgnoreCase) || x.Teams.Any(s => userTeams.Contains(s, StringComparer.OrdinalIgnoreCase))).ToList();
+            return ADBackend.Instance.Repositories.Where(x => 
+                (String.IsNullOrEmpty(username) ? false : x.Users.Contains(username, StringComparer.OrdinalIgnoreCase)) ||
+                x.Teams.Any(s => userTeams.Contains(s, StringComparer.OrdinalIgnoreCase))
+                ).ToList();
         }
 
         public RepositoryModel GetRepository(string name)

--- a/Bonobo.Git.Server/Security/AuthenticationProvider.cs
+++ b/Bonobo.Git.Server/Security/AuthenticationProvider.cs
@@ -27,7 +27,7 @@ namespace Bonobo.Git.Server.Security
         {
             List<Claim> result = null;
 
-            UserModel user = MembershipService.GetUser(username.StripDomain());
+            UserModel user = MembershipService.GetUser(username);
             if (user != null)
             {
                 result = new List<Claim>();


### PR DESCRIPTION
Removed StripDomain() due to the domain being used in the routine that values is parsed into. This also makes it compatible with version 4.0.0 according to @mirogta.

Added the parantheses that I mentioned earlier in #332.