### PR TITLE
Remove the confidence requirement.

### DIFF
--- a/Bonobo.Git.Server/FileDisplayHandler.cs
+++ b/Bonobo.Git.Server/FileDisplayHandler.cs
@@ -595,7 +595,7 @@ namespace Bonobo.Git.Server
             ICharsetDetector cdet = new CharsetDetector();
             cdet.Feed(data, 0, data.Length);
             cdet.DataEnd();
-            if (cdet.Charset != null && cdet.Confidence >= 0.5)
+            if (cdet.Charset != null)
             {
                 if (cdet.Charset.ToLowerInvariant() == "big-5")
                 {
@@ -614,7 +614,7 @@ namespace Bonobo.Git.Server
                 }
             }
 
-            return null;
+            return Encoding.Default;
         }
 
 


### PR DESCRIPTION
Return default encoding if charsetDetector fails to detect.

Should fix #348 as it was detected with 0.499xx