### PR TITLE
Export the correct remote user envirnonment variable

### DIFF
--- a/Bonobo.Git.Server/Git/GitService/GitServiceExecutor.cs
+++ b/Bonobo.Git.Server/Git/GitService/GitServiceExecutor.cs
@@ -53,7 +53,9 @@ namespace Bonobo.Git.Server.Git.GitService
             };
 
             SetHomePath(info);
-            info.EnvironmentVariables.Add("AUTH_USER", HttpContext.Current.Request.ServerVariables["AUTH_USER"]);
+            var userid = HttpContext.Current.User.Id();
+            info.EnvironmentVariables.Add("AUTH_USER", userid);
+            info.EnvironmentVariables.Add("REMOTE_USER", userid);
 
             using (var process = Process.Start(info))
             {


### PR DESCRIPTION
The AUTH_USER server variable is always empty in this version. Furthermore, git hooks expect the REMOTE_USER variable to be set, since that is what git-http-backend uses.

Set both the REMOTE_USER and AUTH_USER variables, but get the authenticated user name from the current http context instead of using the server variables.