### PR TITLE
Attempt to fix windowsAuthCallback redirecting to root of site

### DIFF
--- a/Bonobo.Git.Server/Owin/WindowsAuthenticationHandler.cs
+++ b/Bonobo.Git.Server/Owin/WindowsAuthenticationHandler.cs
@@ -38,7 +38,7 @@ namespace Bonobo.Git.Server.Owin.Windows
                         if (handshake.IsClientResponseValid(token))
                         {
                             properties = handshake.AuthenticationProperties;
-                            if (Options.GetClaimsForUser != null)
+                            if (Options.GetClaimsForUser(handshake.AuthenticatedUsername) != null)
                             {
                                 Claim[] claims = Options.GetClaimsForUser(handshake.AuthenticatedUsername).ToArray();
                                 if (claims.Length > 0)
@@ -86,7 +86,7 @@ namespace Bonobo.Git.Server.Owin.Windows
                     };
 
                     Options.Handshakes.Add(handshakeId, handshake);
-                    Response.Redirect(WebUtilities.AddQueryString(Options.CallbackPath.Value, "id", handshakeId));
+                    Response.Redirect(WebUtilities.AddQueryString(RequestPathBase + Options.CallbackPath.Value, "id", handshakeId));
                 }
             }
 
@@ -97,7 +97,7 @@ namespace Bonobo.Git.Server.Owin.Windows
         {
             bool result = false;
 
-            if (Options.CallbackPath.HasValue && Options.CallbackPath == Request.PathBase.Add(Request.Path))
+            if (Options.CallbackPath.HasValue && Options.CallbackPath == Request.Path)
             {
                 AuthenticationTicket ticket = await AuthenticateAsync();
                 if (ticket != null && ticket.Identity != null)

--- a/Bonobo.Git.Server/Owin/WindowsAuthenticationHandler.cs
+++ b/Bonobo.Git.Server/Owin/WindowsAuthenticationHandler.cs
@@ -86,7 +86,7 @@ namespace Bonobo.Git.Server.Owin.Windows
                     };
 
                     Options.Handshakes.Add(handshakeId, handshake);
-                    Response.Redirect(WebUtilities.AddQueryString(RequestPathBase + Options.CallbackPath.Value, "id", handshakeId));
+                    Response.Redirect(WebUtilities.AddQueryString(Request.PathBase + Options.CallbackPath.Value, "id", handshakeId));
                 }
             }
 

--- a/Bonobo.Git.Server/Security/WindowsAuthenticationProvider.cs
+++ b/Bonobo.Git.Server/Security/WindowsAuthenticationProvider.cs
@@ -30,7 +30,7 @@ namespace Bonobo.Git.Server.Security
                 {
                     OnApplyRedirect = context =>
                     {
-                        if (context.Request.PathBase.Add(context.Request.Path) != WindowsAuthenticationOptions.DefaultRedirectPath && !context.Request.Headers.ContainsKey("AuthNoRedirect"))
+                        if (context.Request.Path != WindowsAuthenticationOptions.DefaultRedirectPath && !context.Request.Headers.ContainsKey("AuthNoRedirect"))
                         {
                             context.Response.Redirect(context.RedirectUri);
                         }

--- a/Bonobo.Git.Server/web.config
+++ b/Bonobo.Git.Server/web.config
@@ -8,7 +8,7 @@
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    
+
     <add key="UserConfiguration" value="~\App_Data\config.xml" />
     <add key="DefaultRepositoriesDirectory" value="~\App_Data\Repositories" />
     <add key="GitPath" value="~\App_Data\Git\git.exe" />
@@ -17,16 +17,16 @@
     <add key="AuthenticationProvider" value="Cookies" />
     <!--<add key="AuthenticationProvider" value="Windows" />-->
     <!--<add key="AuthenticationProvider" value="Federation" />-->
-    
+
     <add key="MembershipService" value="Internal" />
-  
+
     <!--<add key="MembershipService" value="ActiveDirectory" />
     <add key="ActiveDirectoryDefaultDomain" value="domain.local" />
     <add key="ActiveDirectoryBackendPath" value="~\App_Data\ADBackend" />
     <add key="ActiveDirectoryMemberGroupName" value="Git" />
     <add key="ActiveDirectoryTeamMapping" value="Developers=GitTeam" />
     <add key="ActiveDirectoryRoleMapping" value="Administrator=GitAdmins" />-->
-    
+
     <!--<add key="FederationMetadataAddress" value="https://sts.domain.local/federationmetadata/2007-06/federationmetadata.xml" />
     <add key="FederationRealm" value="https://git.domain.local" />-->
   </appSettings>
@@ -116,6 +116,7 @@
   </entityFramework>
   <system.data>
     <DbProviderFactories>
+      <clear />
       <remove invariant="System.Data.SQLite.EF6" />
       <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
       <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".Net Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />


### PR DESCRIPTION
This is my attempt to fix the windowsAuthCallback call redirecting to the root of the site when Bonobo is a subfolder application when configured to use Windows AuthenticationProvider. Works under IIS Express but ends in a 200 response when pushed to IIS 7.5. ( https://github.com/jakubgarfield/Bonobo-Git-Server/issues/345 )