### PR TITLE
Increase button column width to prevent line break caused by long button texts.

### DIFF
--- a/Bonobo.Git.Server/Views/Repository/Index.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Index.cshtml
@@ -27,12 +27,12 @@
 }
 
 <div class="pure-g">
-    <div class="pure-u-3-5">
+    <div class="pure-u-2-5">
         <h1>
             @Resources.Repository_Index_Title
         </h1>
     </div>
-    <div class="pure-u-2-5 add">
+    <div class="pure-u-3-5 add">
         @{
             var sortGroupQuery = Request.QueryString["sortGroup"];
 


### PR DESCRIPTION

![line-break](https://cloud.githubusercontent.com/assets/2137126/12009446/93bdc83a-ac77-11e5-8ea0-02fe215719dd.png)