### PR TITLE
Fix #395 VS2013 packages MSBuild and not .Net.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -4,6 +4,6 @@ set startDrive= %startPath:~0,2%
 set fileDrive=%~dp0
 %fileDrive:~0,2% 
 cd %~dp0
-C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild build.msbuild  /m:4 %*
+msbuild build.msbuild  /m:4 %*
 %startDrive%
 cd %startPath%


### PR DESCRIPTION
Fix by not using absolute path to msbuild.