### PR TITLE
Fix #396 #295 #394 #374 Fix WindowsAuth with Internal DB

### DIFF
--- a/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
+++ b/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
@@ -66,7 +66,7 @@ namespace Bonobo.Git.Server
                         {
                             if (pc.ValidateCredentials(username, password))
                             {
-                                httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(AuthenticationProvider.GetClaimsForUser(username)));
+                                httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(AuthenticationProvider.GetClaimsForUser(username.Replace("\\", "!"))));
                                 allowed = true;
                             }
                         }

--- a/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
+++ b/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
@@ -59,17 +59,24 @@ namespace Bonobo.Git.Server
                 if (AuthenticationProvider is WindowsAuthenticationProvider)
                 {
                     var parts = username.Split('\\');
-                    using (PrincipalContext pc = new PrincipalContext(ContextType.Domain, parts[0]))
+                    try
                     {
-                        var adUser = UserPrincipal.FindByIdentity(pc, username);
-                        if (adUser != null)
+                        using (PrincipalContext pc = new PrincipalContext(ContextType.Domain, parts[0]))
                         {
-                            if (pc.ValidateCredentials(username, password))
+                            var adUser = UserPrincipal.FindByIdentity(pc, username);
+                            if (adUser != null)
                             {
-                                httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(AuthenticationProvider.GetClaimsForUser(username.Replace("\\", "!"))));
-                                allowed = true;
+                                if (pc.ValidateCredentials(username, password))
+                                {
+                                    httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(AuthenticationProvider.GetClaimsForUser(username.Replace("\\", "!"))));
+                                    allowed = true;
+                                }
                             }
                         }
+                    }
+                    catch (PrincipalException)
+                    {
+                        // let it fail
                     }
                 }
                 else

--- a/Bonobo.Git.Server/Attributes/WebAuthorizeAttribute.cs
+++ b/Bonobo.Git.Server/Attributes/WebAuthorizeAttribute.cs
@@ -28,7 +28,7 @@ namespace Bonobo.Git.Server
 
             if (!(filterContext.Result is HttpUnauthorizedResult))
             {
-                if (!filterContext.HttpContext.User.IsInRole(Definitions.Roles.Member))
+                if (!filterContext.HttpContext.User.IsInRole(Definitions.Roles.Member) && !filterContext.HttpContext.User.Identity.IsAuthenticated)
                 {
                     filterContext.Result = new RedirectResult("~/Home/Unauthorized");
                 }

--- a/Bonobo.Git.Server/Configuration/AuthenticationSettings.cs
+++ b/Bonobo.Git.Server/Configuration/AuthenticationSettings.cs
@@ -10,11 +10,13 @@ namespace Bonobo.Git.Server.Configuration
     {
         public static string MembershipService { get; private set; }
         public static string AuthenticationProvider { get; private set; }
+        public static bool ImportWindowsAuthUsersAsAdmin { get; private set; }
 
         static AuthenticationSettings()
         {
             MembershipService = ConfigurationManager.AppSettings["MembershipService"];            
             AuthenticationProvider = ConfigurationManager.AppSettings["AuthenticationProvider"];
+            ImportWindowsAuthUsersAsAdmin = Convert.ToBoolean(ConfigurationManager.AppSettings["ImportWindowsAuthUsersAsAdmin"]);
         }
     }
 }

--- a/Bonobo.Git.Server/Controllers/AccountController.cs
+++ b/Bonobo.Git.Server/Controllers/AccountController.cs
@@ -187,16 +187,17 @@ namespace Bonobo.Git.Server.Controllers
         {
             if ((!Request.IsAuthenticated) || !(MembershipService is EFMembershipService))
             {
-                return RedirectToAction("Unauthorizedx", "Home");
+                return RedirectToAction("Unauthorized", "Home");
             }
 
             var uid = User.Id();
+            var dbuid = uid.Replace("\\", "!");
             var parts = uid.Split('\\');
             var dc = new PrincipalContext(ContextType.Domain, parts[0]);
             var adUser = UserPrincipal.FindByIdentity(dc, uid);
             if (adUser != null)
             {
-                if(MembershipService.CreateUser(uid, "AD_PASSWORD", adUser.GivenName, adUser.Surname, adUser.EmailAddress))
+                if(MembershipService.CreateUser(dbuid, "AD_PASSWORD", adUser.GivenName, adUser.Surname, adUser.EmailAddress))
                 {
                     if (MembershipService is EFMembershipService)
                     {
@@ -204,10 +205,10 @@ namespace Bonobo.Git.Server.Controllers
                         // 2 because we just added the user and there is the default admin user.
                         if ((AuthenticationSettings.ImportWindowsAuthUsersAsAdmin || efms.UserCount() == 2))
                         {
-                            RoleProvider.AddUserToRoles(uid, new string[] {Definitions.Roles.Administrator});
+                            RoleProvider.AddUserToRoles(dbuid, new string[] {Definitions.Roles.Administrator});
                         }
                     }
-                    return RedirectToAction("Edit", PathEncoder.Encode(User.Id()), "Account");
+                    return RedirectToAction("Index", "Repository");
                 }
                 else
                 {

--- a/Bonobo.Git.Server/Controllers/RepositoryController.cs
+++ b/Bonobo.Git.Server/Controllers/RepositoryController.cs
@@ -33,6 +33,9 @@ namespace Bonobo.Git.Server.Controllers
         [Dependency]
         public IRepositoryPermissionService RepositoryPermissionService { get; set; }
 
+        [Dependency]
+        public IAuthenticationProvider AuthenticationProvider { get; set; }
+
         [WebAuthorize]
         public ActionResult Index(string sortGroup = null)
         {
@@ -521,7 +524,14 @@ namespace Bonobo.Git.Server.Controllers
 
         private void PopulateEditData()
         {
-            ViewData["AvailableUsers"] = MembershipService.GetAllUsers().Select(i => i.Name).ToArray();
+            if (AuthenticationProvider is WindowsAuthenticationProvider)
+            {
+                ViewData["AvailableUsers"] = MembershipService.GetAllUsers().Select(i => new List<string>(){i.Name, i.GivenName, i.Surname}).ToArray();
+            }
+            else
+            {
+                ViewData["AvailableUsers"] = MembershipService.GetAllUsers().Select(i => new List<string>(){i.Name}).ToArray();
+            }
             ViewData["AvailableAdministrators"] = ViewData["AvailableUsers"];
             ViewData["AvailableTeams"] = TeamRepository.GetAllTeams().Select(i => i.Name).ToArray();
         }

--- a/Bonobo.Git.Server/Global.asax.cs
+++ b/Bonobo.Git.Server/Global.asax.cs
@@ -50,7 +50,8 @@ namespace Bonobo.Git.Server
                     string langName = "en";
 
                     if (HttpContext.Current.Request.UserLanguages != null &&
-                        HttpContext.Current.Request.UserLanguages.Length != 0)
+                        HttpContext.Current.Request.UserLanguages.Length != 0 &&
+                        HttpContext.Current.Request.UserLanguages[0].Length > 2)
                     {
                         langName = HttpContext.Current.Request.UserLanguages[0].Substring(0, 2);
                     }

--- a/Bonobo.Git.Server/Helpers/CustomHtmlHelpers.cs
+++ b/Bonobo.Git.Server/Helpers/CustomHtmlHelpers.cs
@@ -25,7 +25,7 @@ namespace Bonobo.Git.Server.Helpers
             return MvcHtmlString.Create(markdown.Transform(markdownText));
         }
 
-        public static MvcHtmlString CheckboxListFor<TModel, TValue>(this HtmlHelper<TModel> helper, Expression<Func<TModel, IEnumerable<TValue>>> expression, IEnumerable<SelectListItem> selectList, object htmlAttributes)
+        public static MvcHtmlString CheckboxListFor<TModel, TValue>(this HtmlHelper<TModel> helper, Expression<Func<TModel, IEnumerable<TValue>>> expression, IEnumerable<SelectListItem> selectList, object htmlAttributes, IList<string> labels = null)
         {
             StringBuilder sb = new StringBuilder();
             TagBuilder ul = new TagBuilder("ul");
@@ -36,6 +36,7 @@ namespace Bonobo.Git.Server.Helpers
             string propertyName = ExpressionHelper.GetExpressionText(expression);            
             TModel model = (TModel)helper.ViewContext.ViewData.ModelMetadata.Model;        
             IEnumerable<TValue> collection = expression.Compile().Invoke(model);
+            int index = 0;
 
             if (selectList != null)
             {
@@ -59,6 +60,11 @@ namespace Bonobo.Git.Server.Helpers
                     }
 
                     label.Attributes.Add(new KeyValuePair<string, string>("for", propertyName + "_" + listItem.Value));
+                    if (labels != null)
+                    {
+                        label.Attributes.Add(new KeyValuePair<string, string>("title", labels[index]));
+                        index++;
+                    }
                     label.InnerHtml = listItem.Text;
 
                     li.InnerHtml = input.ToString() + label.ToString();

--- a/Bonobo.Git.Server/Owin/WindowsAuthenticationHandler.cs
+++ b/Bonobo.Git.Server/Owin/WindowsAuthenticationHandler.cs
@@ -133,7 +133,12 @@ namespace Bonobo.Git.Server.Owin.Windows
                 AuthenticationTicket ticket = await AuthenticateAsync();
                 if (ticket != null && ticket.Identity != null)
                 {
+
                     Context.Authentication.SignIn(ticket.Properties, ticket.Identity);
+                    if(!ticket.Properties.RedirectUri.StartsWith(Request.PathBase.Value))
+                    {
+                        ticket.Properties.RedirectUri = Request.PathBase.Value + ticket.Properties.RedirectUri;
+                    }
                     Response.Redirect(ticket.Properties.RedirectUri);
                     result = true;
                 }

--- a/Bonobo.Git.Server/Owin/WindowsAuthenticationHandler.cs
+++ b/Bonobo.Git.Server/Owin/WindowsAuthenticationHandler.cs
@@ -43,7 +43,8 @@ namespace Bonobo.Git.Server.Owin.Windows
                         if (handshake.IsClientResponseValid(token))
                         {
                             properties = handshake.AuthenticationProperties;
-                            var claimdelegate = Options.GetClaimsForUser(handshake.AuthenticatedUsername);
+                            var uid = handshake.AuthenticatedUsername.Replace("\\", "!").ToLowerInvariant();
+                            var claimdelegate = Options.GetClaimsForUser(uid);
 
 
                             if (claimdelegate == null) 
@@ -66,7 +67,7 @@ namespace Bonobo.Git.Server.Owin.Windows
                                 Options.Handshakes.TryRemove(handshakeId);
 
                                 // user does not exist! Redirect to create page.
-                                properties.RedirectUri = "/Account/"+PathEncoder.Encode(handshake.AuthenticatedUsername)+ "/CreateADUser";
+                                properties.RedirectUri = "/Account/" + uid + "/CreateADUser";
                                 return Task.FromResult(new AuthenticationTicket(identity, properties));
 
                             }else{

--- a/Bonobo.Git.Server/Security/EFMembershipService.cs
+++ b/Bonobo.Git.Server/Security/EFMembershipService.cs
@@ -90,6 +90,14 @@ namespace Bonobo.Git.Server.Security
             }
         }
 
+        public int UserCount()
+        {
+            using (var db = _createDatabaseContext())
+            {
+                return db.Users.Count();
+            }
+        }
+
         public UserModel GetUser(string username)
         {
             if (String.IsNullOrEmpty(username)) throw new ArgumentException("Value cannot be null or empty.", "username");

--- a/Bonobo.Git.Server/Views/Account/Delete.cshtml
+++ b/Bonobo.Git.Server/Views/Account/Delete.cshtml
@@ -4,7 +4,7 @@
 }
 <h1>@Resources.Confirm</h1>
 <div>
-    <p class="summary-error">@String.Format(Resources.Delete_ConfirmationText, Model.Username)</p>
+    <p class="summary-error">@String.Format(Resources.Delete_ConfirmationText, Model.Username.Replace("!", "\\"))</p>
 </div>
 
 @using (Html.BeginForm("Delete", "Account", FormMethod.Post, new { @class = "pure-form" }))

--- a/Bonobo.Git.Server/Views/Account/Detail.cshtml
+++ b/Bonobo.Git.Server/Views/Account/Detail.cshtml
@@ -8,13 +8,13 @@
 }
 else
 {  
-    <h1>@Model.Username</h1>
+    <h1>@Model.Username.Replace("!", "\\")</h1>
 
     <div class="pure-form pure-form-aligned detail">
         <fieldset>
             <div class="pure-control-group">
                 @Html.LabelFor(m => m.Username)
-                <span>@Model.Username</span>
+                <span>@Model.Username.Replace("!", "\\")</span>
             </div>
             <div class="pure-control-group">
                 @Html.LabelFor(m => m.Name)

--- a/Bonobo.Git.Server/Views/Account/Edit.cshtml
+++ b/Bonobo.Git.Server/Views/Account/Edit.cshtml
@@ -9,7 +9,7 @@
 else
 {
     <text>
-    <h1>@Model.Username</h1>
+    <h1>@Model.Username.Replace("!", "\\")</h1>
 
     @if (ViewBag.UpdateSuccess != null && ViewBag.UpdateSuccess)
     {

--- a/Bonobo.Git.Server/Views/Account/Index.cshtml
+++ b/Bonobo.Git.Server/Views/Account/Index.cshtml
@@ -45,7 +45,7 @@
     @grid.GetHtml(
         tableStyle: "pure-table users",
         columns: grid.Columns(
-        grid.Column("Username", header: typeof(UserDetailModel).GetDisplayValue("Username"), format: (item) => Html.ActionLink((string)item.Username, "Detail", new { id = item.Username }, new { @class = "detail" })),
+        grid.Column("Username", header: typeof(UserDetailModel).GetDisplayValue("Username"), format: (item) => Html.ActionLink((string)item.Username.Replace("!", "\\"), "Detail", new { id = item.Username }, new { @class = "detail" })),
             grid.Column("Name", typeof(UserDetailModel).GetDisplayValue("Name")),
             grid.Column("Surname", typeof(UserDetailModel).GetDisplayValue("Surname")),
             grid.Column("Email", typeof(UserDetailModel).GetDisplayValue("Email")),

--- a/Bonobo.Git.Server/Views/Repository/Create.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Create.cshtml
@@ -37,21 +37,54 @@
             <div class="pure-control-group checkboxlist">
                 @Html.LabelFor(m => m.Users)
                 @{
-                    var users = (from u in ViewData["AvailableUsers"] as string[]
+                    
+                    IList<SelectListItem> users = null;
+                    IList<string> titles = null;
+                    IList<string>[] ud = (IList<string>[])ViewData["AvailableUsers"];
+                    if (ud.Count() > 0 && ud[0].Count > 1)
+                    {
+                        users = (from u in ud 
+                                 orderby u[1] + u[2]
+                                 select new SelectListItem() { Value = u[0], Text = (u[1] + " " + u[2]) }).ToArray();
+                        titles = (from u in ud 
+                                  orderby u[1] + u[2]
+                                  select u[0].Replace("!", "\\")).ToArray();
+
+                    }
+                    else
+                    {
+                        users = (from u in ud
                                  orderby u
-                                 select new SelectListItem() { Value = u, Text = u }).ToArray();
+                                 select new SelectListItem() { Value = u[0], Text = u[0].Replace("!", "\\") }).ToArray();
+                    }
                 }
 
-                @Html.CheckboxListFor(m => m.Users, users)
+                @Html.CheckboxListFor(m => m.Users, users, null, titles)
                 <i class="fa fa-info-circle" title="@Resources.Repository_UsersHint"></i>
             </div>
 
             <div class="pure-control-group checkboxlist">
                 @Html.LabelFor(m => m.Administrators)
                 @{
-                    var administrators = (from u in ViewData["AvailableAdministrators"] as string[]
-                                          orderby u
-                                          select new SelectListItem() { Value = u, Text = u }).ToArray();
+                    IList<SelectListItem> administrators = null;
+                    titles = null;
+                    IList<string>[] ad = (IList<string>[])ViewData["AvailableAdministrators"];
+                    if (ad.Count() > 0 && ad[0].Count() > 1)
+                    {
+                        administrators = (from u in ad
+                                              orderby u[1] + u[2]
+                                              select new SelectListItem(){Value = u[0], Text = (u[1] + " " + u[2])}).ToArray();
+                        titles = (from u in ad
+                                              orderby u[1] + u[2]
+                                              select u[0].Replace("!", "\\")).ToArray();
+                    }
+                    else
+                    {
+
+                        administrators = (from u in ad
+                                          orderby u[0]
+                                          select new SelectListItem() { Value = u[0], Text = u[0].Replace("!", "\\") }).ToArray();
+                    }
                 }
 
                 @Html.CheckboxListFor(m => m.Administrators, administrators)

--- a/Bonobo.Git.Server/Views/Repository/Detail.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Detail.cshtml
@@ -86,7 +86,7 @@
                 @Html.LabelFor(m => m.Users)
                 @for (int i = 0; i < Model.Users.Length; i++)
                 {
-                        @Html.ActionLink(@Model.Users[i], "Detail", "Account", new { id = @Model.Users[i] }, null)
+                        @Html.ActionLink(@Model.Users[i].Replace("!", "\\"), "Detail", "Account", new { id = @Model.Users[i]}, new { title = "My title" })
                         if (i + 1 != Model.Users.Length)
                         {
                             <text>, </text>
@@ -97,7 +97,7 @@
                 @Html.LabelFor(m => m.Administrators)
                 @for (int i = 0; i < Model.Administrators.Length; i++)
                     {
-                        @Html.ActionLink(@Model.Administrators[i], "Detail", "Account", new { id = @Model.Administrators[i] }, null)
+                        @Html.ActionLink(@Model.Administrators[i].Replace("!", "\\"), "Detail", "Account", new { id = @Model.Administrators[i] }, null)
                         if (i + 1 != Model.Administrators.Length)
                         {
                             <text>, </text>

--- a/Bonobo.Git.Server/Views/Repository/Detail.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Detail.cshtml
@@ -44,8 +44,8 @@
                         @Resources.Repository_Detail_Location_Personal
                     </label>
 
-                    <a href=@String.Concat(serverAddress.Replace("://", "://" + Uri.EscapeDataString(User.Id()) + "@"), Model.Name, ".git")>
-                        @String.Concat(serverAddress.Replace("://", "://" + Uri.EscapeDataString(User.Id()) + "@"), Model.Name, ".git")
+                    <a href=@String.Concat(serverAddress.Replace("://", "://" + Uri.EscapeDataString(User.Id()).Replace("!", "\\") + "@"), Model.Name, ".git")>
+                        @String.Concat(serverAddress.Replace("://", "://" + Uri.EscapeDataString(User.Id()).Replace("!", "\\") + "@"), Model.Name, ".git")
                     </a>
                 </div>
             }

--- a/Bonobo.Git.Server/Views/Repository/Detail.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Detail.cshtml
@@ -44,8 +44,8 @@
                         @Resources.Repository_Detail_Location_Personal
                     </label>
 
-                    <a href=@String.Concat(serverAddress.Replace("://", "://" + Uri.EscapeDataString(User.Id()).Replace("!", "\\") + "@"), Model.Name, ".git")>
-                        @String.Concat(serverAddress.Replace("://", "://" + Uri.EscapeDataString(User.Id()).Replace("!", "\\") + "@"), Model.Name, ".git")
+                    <a href=@String.Concat(serverAddress.Replace("://", "://" + Uri.EscapeDataString(User.Id()) + "@").Replace("!", "\\"), Model.Name, ".git")>
+                        @String.Concat(serverAddress.Replace("://", "://" + Uri.EscapeDataString(User.Id()) + "@").Replace("!", "\\"), Model.Name, ".git")
                     </a>
                 </div>
             }

--- a/Bonobo.Git.Server/Views/Repository/Edit.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Edit.cshtml
@@ -67,12 +67,28 @@ else
             <div class="pure-control-group checkboxlist">
                 @Html.LabelFor(m => m.Users)
                 @{
-                    var users = (from u in ViewData["AvailableUsers"] as string[]
-                        orderby u
-                                     select new SelectListItem() { Value = u, Text = u }).ToArray();
+                    IList<SelectListItem> users = null;
+                    IList<string> titles = null;
+                    IList<string>[] ud = (IList<string>[])ViewData["AvailableUsers"];
+                    if (ud.Count() > 0 && ud[0].Count > 1)
+                    {
+                        users = (from u in ud 
+                                 orderby u[1] + u[2]
+                                 select new SelectListItem() { Value = u[0], Text = (u[1] + " " + u[2]) }).ToArray();
+                        titles = (from u in ud 
+                                  orderby u[1] + u[2]
+                                  select u[0].Replace("!", "\\")).ToArray();
+
+                    }
+                    else
+                    {
+                        users = (from u in ud
+                                 orderby u
+                                 select new SelectListItem() { Value = u[0], Text = u[0].Replace("!", "\\") }).ToArray();
+                    }
                 }
 
-                    @Html.CheckboxListFor(m => m.Users, users, new { @class = "checkboxList medium" })
+                    @Html.CheckboxListFor(m => m.Users, users, new { @class = "checkboxList medium" }, titles)
                 <i class="fa fa-info-circle" title="@Resources.Repository_UsersHint"></i>
             </div>
 
@@ -81,12 +97,29 @@ else
             <div class="pure-control-group checkboxlist">
                 @Html.LabelFor(m => m.Administrators)
                 @{
-                    var Administrators = (from u in ViewData["AvailableAdministrators"] as string[]
-                        orderby u
-                                              select new SelectListItem() { Value = u, Text = u }).ToArray();
+                    IList<SelectListItem> administrators = null;
+                    titles = null;
+                    IList<string>[] ad = (IList<string>[])ViewData["AvailableAdministrators"];
+                    if (ad.Count() > 0 && ad[0].Count() > 1)
+                    {
+                        administrators = (from u in ad
+                                              orderby u[1] + u[2]
+                                              select new SelectListItem(){Value = u[0], Text = (u[1] + " " + u[2])}).ToArray();
+                        titles = (from u in ad
+                                              orderby u[1] + u[2]
+                                              select u[0].Replace("!", "\\")).ToArray();
+                    }
+                    else
+                    {
+
+                        administrators = (from u in ad
+                                          orderby u[0]
+                                          select new SelectListItem() { Value = u[0], Text = u[0].Replace("!", "\\") }).ToArray();
+                    }
+        
                 }
 
-                    @Html.CheckboxListFor(m => m.Administrators, Administrators, new { @class = "checkboxList medium" })
+                    @Html.CheckboxListFor(m => m.Administrators, administrators, new { @class = "checkboxList medium" }, titles)
                 <i class="fa fa-info-circle" title="@Resources.Repository_AdministratorsHint"></i>
                 @Html.ValidationMessageFor(m => m.Administrators)
             </div>

--- a/Bonobo.Git.Server/Views/Shared/_Layout.cshtml
+++ b/Bonobo.Git.Server/Views/Shared/_Layout.cshtml
@@ -33,7 +33,7 @@
                     }
                     @if (Request.IsAuthenticated)
                     {
-                        <li class="separator"><a href="@Url.Action("Edit", "Account", new { id = User.Id() })"><i class="fa fa-male"></i> @User.Name()</a></li>
+                        <li class="separator"><a href="@Url.Action("Edit", "Account", new { id = User.Id().Replace("\\", "!") })"><i class="fa fa-male"></i> @User.Name()</a></li>
                         if (!User.IsWindowsAuthenticated())
                         {
                             <li><a href="@Url.Action("LogOff", "Home")"><i class="fa fa-sign-out"></i> @Resources.Layout_LogOff</a></li>

--- a/Bonobo.Git.Server/Views/Team/Create.cshtml
+++ b/Bonobo.Git.Server/Views/Team/Create.cshtml
@@ -22,7 +22,7 @@
             @{
                 var users = (from u in ViewData["AvailableUsers"] as string[]
                              orderby u
-                             select new SelectListItem() { Value = u, Text = u }).ToArray();
+                             select new SelectListItem() { Value = u, Text = u.Replace("!", "\\") }).ToArray();
             }
 
             @Html.LabelFor(m => m.Members)

--- a/Bonobo.Git.Server/Views/Team/Detail.cshtml
+++ b/Bonobo.Git.Server/Views/Team/Detail.cshtml
@@ -25,7 +25,7 @@ else
                 <span>
                     @for (int i = 0; i < Model.Members.Length; i++)
                     {
-                        @Html.ActionLink(@Model.Members[i], "Detail", "Account", new { id = @Model.Members[i] }, null)if (i + 1 != Model.Members.Length)
+                        @Html.ActionLink(@Model.Members[i].Replace("!", "\\"), "Detail", "Account", new { id = @Model.Members[i] }, null)if (i + 1 != Model.Members.Length)
                         {<text>, </text>}
                     }
                 </span>

--- a/Bonobo.Git.Server/Views/Team/Edit.cshtml
+++ b/Bonobo.Git.Server/Views/Team/Edit.cshtml
@@ -33,7 +33,7 @@ else
                 @{
                     var users = (from u in ViewData["AvailableUsers"] as string[]
                                  orderby u
-                                 select new SelectListItem() { Value = u, Text = u }).ToArray();
+                                 select new SelectListItem() { Value = u, Text = u.Replace("!", "\\") }).ToArray();
                 }
 
                 @Html.CheckboxListFor(m => m.Members, users, new { @class = "checkboxList medium" })

--- a/Bonobo.Git.Server/web.config
+++ b/Bonobo.Git.Server/web.config
@@ -16,6 +16,7 @@
     <add key="RecoveryDataPath" value="~\App_Data\Recovery" />
     <add key="AuthenticationProvider" value="Cookies" />
     <!--<add key="AuthenticationProvider" value="Windows" />-->
+    <add key="ImportWindowsAuthUsersAsAdmin" value="false" />
     <!--<add key="AuthenticationProvider" value="Federation" />-->
 
     <add key="MembershipService" value="Internal" />


### PR DESCRIPTION
Added option ImportWindowsAuthUsersAsAdmin to be able to import all users automatically as admins if wanted. The first user is always imported as admin.

Since we cannot store the Password (we never see it) added WindowsAuth also to Gitauthorization.

Usernames are now saved again with the domain separator in the name as that is how i see it on the back side.

The edit user page does not work at the moment. I'm lookin into it.

Hopefully this fixes #396 #295 #394 #374 without introducing too many new problems.

Pinging @Ollienator since he introduced most of the new OWIN auth part.

