### PR TITLE
Better commits paging

### DIFF
--- a/Bonobo.Git.Server/Controllers/RepositoryController.cs
+++ b/Bonobo.Git.Server/Controllers/RepositoryController.cs
@@ -369,8 +369,10 @@ namespace Bonobo.Git.Server.Controllers
         }
 
         [WebAuthorizeRepository]
-        public ActionResult Commits(string id, string encodedName)
+        public ActionResult Commits(string id, string encodedName, int page = 1)
         {
+            page = page >= 1 ? page : 1;
+            
             ViewBag.ID = id;
             ViewBag.ShowShortMessageOnly = true;
             if (!String.IsNullOrEmpty(id))
@@ -379,8 +381,10 @@ namespace Bonobo.Git.Server.Controllers
                 {
                     var name = PathEncoder.Decode(encodedName);
                     string referenceName;
-                    var commits = browser.GetCommits(name, out referenceName);
+                    int totalCount;
+                    var commits = browser.GetCommits(name, page, 10, out referenceName, out totalCount);
                     PopulateBranchesData(browser, referenceName);
+                    ViewBag.TotalCount = totalCount;
                     return View(new RepositoryCommitsModel { Commits = commits, Name = id });
                 }
             }

--- a/Bonobo.Git.Server/Views/Repository/Commits.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Commits.cshtml
@@ -10,7 +10,8 @@
         @Html.Partial("_BranchSwitcher")
         @if (Model.Commits != null)
         {
-            var grid = new WebGrid(source: Model.Commits, rowsPerPage: 10, canPage:true, canSort:false);
+            var grid = new WebGrid(rowsPerPage: 10, canPage:true, canSort:false);
+            grid.Bind(Model.Commits, null, false, (int)(ViewBag.TotalCount ?? 0));
             @grid.GetHtml(displayHeader: false, mode: WebGridPagerModes.All, 
                 columns: grid.Columns(
                     grid.Column(format: item => Html.Partial("_Commit", (RepositoryCommitModel)item.Value))


### PR DESCRIPTION
Load only commits of the current page directly in RepositoryBrowser.
I test it on a 11000 commits repository and it take less than 800ms for any page.
(Debug mode + standard HDD)