### PR TITLE
Fix #344 Allow anonymous pulls/clone.

### DIFF
--- a/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
+++ b/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
@@ -22,6 +22,9 @@ namespace Bonobo.Git.Server
         [Dependency]
         public IAuthenticationProvider AuthenticationProvider { get; set; }
 
+        [Dependency]
+        public IRepositoryPermissionService RepositoryPermissionService { get; set; }
+
         public override void OnAuthorization(System.Web.Mvc.AuthorizationContext filterContext)
         {
             if (filterContext == null)
@@ -30,6 +33,14 @@ namespace Bonobo.Git.Server
             }
 
             HttpContextBase httpContext = filterContext.HttpContext;
+
+            // check if repo allows anonymous pulls
+            var repo = httpContext.Request.Path.Replace(httpContext.Request.ApplicationPath, "");
+            repo = repo.Substring(1, repo.IndexOf(".git")-1);
+            if (RepositoryPermissionService.AllowsAnonymous(repo))
+            {
+                return;
+            }
 
             if (httpContext.Request.IsAuthenticated && httpContext.User != null && httpContext.User.Identity is System.Security.Claims.ClaimsIdentity)
             {

--- a/Bonobo.Git.Server/Controllers/GitController.cs
+++ b/Bonobo.Git.Server/Controllers/GitController.cs
@@ -22,8 +22,8 @@ namespace Bonobo.Git.Server.Controllers
 
         public ActionResult SecureGetInfoRefs(String project, String service)
         {
-            if (RepositoryPermissionService.HasPermission(User.Id(), project)
-                || (RepositoryPermissionService.AllowsAnonymous(project)
+            if (RepositoryPermissionService.AllowsAnonymous(project)
+                || (RepositoryPermissionService.HasPermission(User.Id(), project)
                     && (String.Equals("git-upload-pack", service, StringComparison.OrdinalIgnoreCase)
                         || UserConfiguration.Current.AllowAnonymousPush)))
             {


### PR DESCRIPTION
Had to invert the check order in SecureGetInfoRefs. Not sure why we check if we can push there...