### PR TITLE
Make life easier for new contributors.

### DIFF
--- a/nuget-packages.msbuild
+++ b/nuget-packages.msbuild
@@ -4,7 +4,7 @@
 		<MainSolution>$(MSBuildThisFileDirectory)\Bonobo.Git.Server.sln</MainSolution>
     </PropertyGroup>
 	
-	<UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll">
+	<UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
        <ParameterGroup>
            <OutputFilename ParameterType="System.String" Required="true" />
        </ParameterGroup>

--- a/run-tests.cmd
+++ b/run-tests.cmd
@@ -1,0 +1,17 @@
+
+set config=Debug
+
+
+rem END OF CONFIGURATIONS
+
+set curpath=%CD%
+
+call setup-env.cmd
+
+msbuild Bonobo.Git.Server.sln /m /property:Configuration=%config%
+if exist Bonobo.Git.Server.Test/bin/%config%/Bonobo.Git.Server.Test.dll (
+	cd Bonobo.Git.Server.Test/bin/%config%
+	mstest /testcontainer:Bonobo.Git.Server.Test.dll
+)
+
+cd %curpath%

--- a/setup-env.cmd
+++ b/setup-env.cmd
@@ -1,0 +1,3 @@
+
+msbuild nuget-packages.msbuild
+


### PR DESCRIPTION
Add setup-env script to get all the necessary nuget packages.
Add run-tests script to run all the tests.