### PR TITLE
Normalize incoming repository names

### DIFF
--- a/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
+++ b/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
@@ -7,7 +7,7 @@ using System.Text;
 using System.Web;
 using System.Web.Mvc;
 using System.DirectoryServices.AccountManagement;
-
+using Bonobo.Git.Server.Data;
 using Bonobo.Git.Server.Security;
 
 using Microsoft.Practices.Unity;
@@ -25,6 +25,9 @@ namespace Bonobo.Git.Server
         [Dependency]
         public IRepositoryPermissionService RepositoryPermissionService { get; set; }
 
+        [Dependency]
+        public IRepositoryRepository RepositoryRepository { get; set; }
+
         public static string GetRepoPath(string path, string applicationPath)
         {
             var repo = path.Replace(applicationPath, "").Replace("/","");
@@ -40,7 +43,9 @@ namespace Bonobo.Git.Server
 
             HttpContextBase httpContext = filterContext.HttpContext;
 
-            string repo = GetRepoPath(httpContext.Request.Path, httpContext.Request.ApplicationPath);
+            string incomingRepoName = GetRepoPath(httpContext.Request.Path, httpContext.Request.ApplicationPath);
+            string repo = Repository.NormalizeRepositoryName(incomingRepoName, RepositoryRepository);
+
             // check if repo allows anonymous pulls
             if (RepositoryPermissionService.AllowsAnonymous(repo))
             {

--- a/Bonobo.Git.Server/Attributes/RepositoryNameNormalizerAttribute.cs
+++ b/Bonobo.Git.Server/Attributes/RepositoryNameNormalizerAttribute.cs
@@ -1,0 +1,41 @@
+using System.Web.Mvc;
+using Bonobo.Git.Server.Data;
+using Microsoft.Practices.Unity;
+
+namespace Bonobo.Git.Server
+{
+    /// <summary>
+    /// Applied to a Controller or Action, this attribute will ensure that a repo/project name has its case corrected to match that in the database
+    /// If the name doesn't match anything in the database, then it's returned unchanged
+    /// The name of the action parameter to be corrected is passed as a constructor parameter
+    /// Normalising the name of the repos at this early stage means that later stages do not have to be concerned about trying 
+    /// to do case-insensitive lookups in databases
+    /// </summary>
+    public class RepositoryNameNormalizerAttribute : ActionFilterAttribute
+    {
+        private readonly string _repositoryNameParameterName;
+
+        public RepositoryNameNormalizerAttribute(string repositoryNameParameterName)
+        {
+            _repositoryNameParameterName = repositoryNameParameterName;
+        }
+
+        [Dependency]
+        public IRepositoryRepository RepositoryRepository { get; set; }
+
+        public override void OnActionExecuting(ActionExecutingContext filterContext)
+        {
+            object incomingProjectParameter;
+            if(filterContext.ActionParameters.TryGetValue(_repositoryNameParameterName, out incomingProjectParameter))
+            {
+                var incomingProjectName = (string)incomingProjectParameter;
+                var normalizedName = Repository.NormalizeRepositoryName(incomingProjectName, RepositoryRepository);
+                if (normalizedName != incomingProjectName)
+                {
+                    // We've had to correct the incoming project name
+                    filterContext.ActionParameters[_repositoryNameParameterName] = normalizedName;
+                }
+            }
+        }
+    }
+}

--- a/Bonobo.Git.Server/Attributes/WebAuthorizeRepositoryAttribute.cs
+++ b/Bonobo.Git.Server/Attributes/WebAuthorizeRepositoryAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System.Web.Mvc;
 using System.Web.Routing;
-
+using Bonobo.Git.Server.Data;
 using Bonobo.Git.Server.Security;
 
 using Microsoft.Practices.Unity;
@@ -12,6 +12,9 @@ namespace Bonobo.Git.Server
         [Dependency]
         public IRepositoryPermissionService RepositoryPermissionService { get; set; }
 
+        [Dependency]
+        public IRepositoryRepository RepositoryRepository { get; set; }
+
         public bool RequiresRepositoryAdministrator { get; set; }
 
         public override void OnAuthorization(AuthorizationContext filterContext)
@@ -20,7 +23,9 @@ namespace Bonobo.Git.Server
 
             if (!(filterContext.Result is HttpUnauthorizedResult))
             {
-                string repository = filterContext.Controller.ControllerContext.RouteData.Values["id"].ToString();
+                string incomingRepoName = filterContext.Controller.ControllerContext.RouteData.Values["id"].ToString();
+                string repository = Repository.NormalizeRepositoryName(incomingRepoName, RepositoryRepository);
+
                 string user = filterContext.HttpContext.User.Id();
 
                 if (filterContext.HttpContext.User.IsInRole(Definitions.Roles.Administrator))

--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -260,6 +260,7 @@
     <Compile Include="App_Start\UnityConfig.cs" />
     <Compile Include="App_Start\UnityMvcActivator.cs" />
     <Compile Include="Attributes\FileExtensionsCustom.cs" />
+    <Compile Include="Attributes\RepositoryNameNormalizerAttribute.cs" />
     <Compile Include="Configuration\ActiveDirectorySettings.cs" />
     <Compile Include="Configuration\AuthenticationSettings.cs" />
     <Compile Include="Configuration\FederationSettings.cs" />

--- a/Bonobo.Git.Server/Controllers/GitController.cs
+++ b/Bonobo.Git.Server/Controllers/GitController.cs
@@ -12,6 +12,7 @@ using Microsoft.Practices.Unity;
 namespace Bonobo.Git.Server.Controllers
 {
     [GitAuthorize]
+    [RepositoryNameNormalizer("project")]
     public class GitController : Controller
     {
         [Dependency]

--- a/Bonobo.Git.Server/Controllers/RepositoryController.cs
+++ b/Bonobo.Git.Server/Controllers/RepositoryController.cs
@@ -19,6 +19,7 @@ using MimeTypes;
 
 namespace Bonobo.Git.Server.Controllers
 {
+    [RepositoryNameNormalizer("id")]
     public class RepositoryController : Controller
     {
         [Dependency]

--- a/Bonobo.Git.Server/Data/Repository.cs
+++ b/Bonobo.Git.Server/Data/Repository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Bonobo.Git.Server.Data
 {
@@ -52,5 +53,39 @@ namespace Bonobo.Git.Server.Data
         }
 
         public bool AuditPushUser { get; set; }
+
+
+        /// <summary>
+        /// Correct a repository name have the same case as it has in the database
+        /// If the repo is not in the database, then the name is returned unchanged
+        /// </summary>
+        public static string NormalizeRepositoryName(string incomingProjectName, IRepositoryRepository repositoryRepository)
+        {
+            // In the most common case, we're just going to find the repo straight off
+            // This is fastest if it succeeds, but might be case-sensitive
+            var knownRepos = repositoryRepository.GetRepository(incomingProjectName);
+            if (knownRepos != null)
+            {
+                return knownRepos.Name;
+            }
+
+            // We might have a real repo, but it wasn't returned by GetRepository, because that's not 
+            // guaranteed to be case insensitive (very difficult to assure this with EF, because it's the back
+            // end which matters, not EF itself)
+            // We'll try and check all repos in a slow but safe fashion
+            knownRepos =
+                repositoryRepository.GetAllRepositories()
+                    .FirstOrDefault(
+                        repo => repo.Name.Equals(incomingProjectName, StringComparison.OrdinalIgnoreCase));
+            if (knownRepos != null)
+            {
+                // We've found it now
+                return knownRepos.Name;
+            }
+
+            // We can't find this repo - it's probably invalid, but it's not
+            // our job to worry about that
+            return incomingProjectName;
+        }
     }
 }


### PR DESCRIPTION
Addresses issue #443 - all review comments appreciated!

This PR corrects repository names as they come into to either GitController or RepositoryController, so that they match the case of the repo name already in the database.   This then allows them to be used subsequently without concern about case-insensitive comparisons.

It turns out to be very difficult to do case-insensitive lookups in a robust way with the EF provider - the behaviour is dependent on the database - for example, I think a SQLServer back end would, by default, be case insensitive, but the Sqlite back end is case-sensitive.  Moreover, doing a FirstOrDefault query against the Sqlite database even with a Compare() / OrdinalIgnoreCase still does a case-sensitive lookup.

I was also concerned that people would forget to use a case-insensitive comparison everywhere when extending the code, and that we'd have weird bugs in the future.

So, to avoid all this, I think it's better to normalise the names right up-front as they hit the API.

Unfortunately I had to do this twice on each call - once in the Authorize attributes, which need to look at permissions, but are too early to re-write Action parameters, then again in an ActionFilter, so that action parameters are rewritten.  I don't know if there's a better solution to this.
