### PR TITLE
Added a button to rescan the repo directory

### DIFF
--- a/Bonobo.Git.Server/Content/Site.css
+++ b/Bonobo.Git.Server/Content/Site.css
@@ -108,6 +108,7 @@ nav.branches ul li:hover ul li { float: none; }
 .Tree #files .date { width: 150px;}
 .breadcrumbs { padding: 7px; margin: 0; }
 .breadcrumbs em { font-weight: bold; font-style: normal; }
+.inline-form { display: inline-block; }
 
 .blob { border: 1px solid #ddd; margin: 2em 0; }
 .blob .controls { border-bottom: 1px solid #ddd; text-shadow: 0 1px 0 #fff; background-image: linear-gradient(#fafafa, #eaeaea); background-repeat: repeat-x; padding-right: 1em;}

--- a/Bonobo.Git.Server/Controllers/RepositoryController.cs
+++ b/Bonobo.Git.Server/Controllers/RepositoryController.cs
@@ -8,6 +8,7 @@ using System.Web.Mvc;
 using Bonobo.Git.Server.App_GlobalResources;
 using Bonobo.Git.Server.Configuration;
 using Bonobo.Git.Server.Data;
+using Bonobo.Git.Server.Data.Update;
 using Bonobo.Git.Server.Helpers;
 using Bonobo.Git.Server.Models;
 using Bonobo.Git.Server.Security;
@@ -544,6 +545,16 @@ namespace Bonobo.Git.Server.Controllers
             }
 
             return View();
+        }
+
+        [HttpPost]
+        [WebAuthorize(Roles = Definitions.Roles.Administrator)]
+        // This takes an irrelevant ID, because there isn't a good route
+        // to RepositoryController for anything without an Id which isn't the Index action
+        public ActionResult Rescan(string id)
+        {
+            new RepositorySynchronizer().Run();
+            return RedirectToAction("Index");
         }
 
         private void PopulateAddressBarData(string path)

--- a/Bonobo.Git.Server/Views/Repository/Index.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/Index.cshtml
@@ -48,6 +48,10 @@
         {
             <a class="pure-button pure-button-primary" href="@Url.Action("Create")"><i class="fa fa-plus-circle"></i> @Resources.Repository_Index_CreateNew</a>
         }
+        @if (User.IsInRole(Definitions.Roles.Administrator))
+        {
+            <form action="@Url.Action("Rescan", new { id = "x" })" method="post" class="inline-form"><button type="submit" class="pure-button pure-button-primary"><i class="fa fa-refresh"></i> Rescan Directory</button></form>
+        }
     </div>
 </div>
 


### PR DESCRIPTION
This adds a button to the repository index which re-runs the directory scan, that's normally only run at startup.  This avoids the need to restart the whole app (which tends to need access to the server) if you've just added a repo directly to the file system.

* I passed a dummy Id to the action method to avoid needing to mess with the routing table.   
* The messing about with the form for the button is so that the action is POSTed rather than GET.