### PR TITLE
[RFC] Allow push-to-create

### DIFF
--- a/Bonobo.Git.Server/App_GlobalResources/Resources.Designer.cs
+++ b/Bonobo.Git.Server/App_GlobalResources/Resources.Designer.cs
@@ -1827,6 +1827,24 @@ namespace Bonobo.Git.Server.App_GlobalResources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow push to create repositories.
+        /// </summary>
+        public static string Settings_Global_AllowPushToCreate {
+            get {
+                return ResourceManager.GetString("Settings_Global_AllowPushToCreate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If checkbox is checked, Administrators can push a new repository .
+        /// </summary>
+        public static string Settings_Global_AllowPushToCreate_Hint {
+            get {
+                return ResourceManager.GetString("Settings_Global_AllowPushToCreate_Hint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Allow user repository creation.
         /// </summary>
         public static string Settings_Global_AllowUserRepositoryCreation {

--- a/Bonobo.Git.Server/App_GlobalResources/Resources.resx
+++ b/Bonobo.Git.Server/App_GlobalResources/Resources.resx
@@ -682,6 +682,12 @@
   <data name="Settings_Global_AllowUserRepositoryCreation_Hint" xml:space="preserve">
     <value>If checkbox is unchecked, only administrators can create repositories.</value>
   </data>
+  <data name="Settings_Global_AllowPushToCreate" xml:space="preserve">
+    <value>Allow push to create repositories</value>
+  </data>
+  <data name="Settings_Global_AllowPushToCreate_Hint" xml:space="preserve">
+    <value>If checkbox is checked, Administrators can push a new repository </value>
+  </data>
   <data name="Delete_Back" xml:space="preserve">
     <value>Back</value>
   </data>

--- a/Bonobo.Git.Server/Configuration/UserConfiguration.cs
+++ b/Bonobo.Git.Server/Configuration/UserConfiguration.cs
@@ -16,6 +16,7 @@ namespace Bonobo.Git.Server.Configuration
         [XmlElementAttribute(ElementName = "Repositories")]
         public string RepositoryPath { get; set; }
         public bool AllowUserRepositoryCreation { get; set; }
+        public bool AllowPushToCreate { get; set; }
         public bool AllowAnonymousRegistration { get; set; }
         public string DefaultLanguage { get; set; }
         public string SiteTitle { get; set; }

--- a/Bonobo.Git.Server/Controllers/SettingsController.cs
+++ b/Bonobo.Git.Server/Controllers/SettingsController.cs
@@ -24,6 +24,7 @@ namespace Bonobo.Git.Server.Controllers
                 RepositoryPath = UserConfiguration.Current.RepositoryPath,
                 AllowAnonymousRegistration = UserConfiguration.Current.AllowAnonymousRegistration,
                 AllowUserRepositoryCreation = UserConfiguration.Current.AllowUserRepositoryCreation,
+                AllowPushToCreate = UserConfiguration.Current.AllowPushToCreate,
                 DefaultLanguage = UserConfiguration.Current.DefaultLanguage,
                 SiteTitle = UserConfiguration.Current.SiteTitle,
                 SiteLogoUrl = UserConfiguration.Current.SiteLogoUrl,
@@ -50,6 +51,7 @@ namespace Bonobo.Git.Server.Controllers
                         UserConfiguration.Current.RepositoryPath = model.RepositoryPath;
                         UserConfiguration.Current.AllowAnonymousRegistration = model.AllowAnonymousRegistration;
                         UserConfiguration.Current.AllowUserRepositoryCreation = model.AllowUserRepositoryCreation;
+                        UserConfiguration.Current.AllowPushToCreate = model.AllowPushToCreate;
                         UserConfiguration.Current.DefaultLanguage = model.DefaultLanguage;
                         UserConfiguration.Current.SiteTitle = model.SiteTitle;
                         UserConfiguration.Current.SiteLogoUrl = model.SiteLogoUrl;

--- a/Bonobo.Git.Server/Models/SettingsModels.cs
+++ b/Bonobo.Git.Server/Models/SettingsModels.cs
@@ -18,6 +18,9 @@ namespace Bonobo.Git.Server.Models
         [Display(ResourceType = typeof(Resources), Name = "Settings_Global_AllowUserRepositoryCreation")]
         public bool AllowUserRepositoryCreation { get; set; }
 
+        [Display(ResourceType = typeof(Resources), Name = "Settings_Global_AllowPushToCreate")]
+        public bool AllowPushToCreate { get; set; }
+
         [Required(ErrorMessageResourceType = typeof(Resources), ErrorMessageResourceName = "Validation_Required")]
         [Display(ResourceType = typeof(Resources), Name = "Settings_Global_RepositoryPath")]
         public string RepositoryPath { get; set; }

--- a/Bonobo.Git.Server/Security/ADRepositoryPermissionService.cs
+++ b/Bonobo.Git.Server/Security/ADRepositoryPermissionService.cs
@@ -23,7 +23,8 @@ namespace Bonobo.Git.Server.Security
 
         public bool AllowsAnonymous(string repositoryName)
         {
-            return Repository.GetRepository(repositoryName).AnonymousAccess;
+            var repository = Repository.GetRepository(repositoryName);
+            return repository != null && repository.AnonymousAccess;
         }
 
         public bool HasPermission(string username, string repositoryName)

--- a/Bonobo.Git.Server/Security/EFRepositoryPermissionService.cs
+++ b/Bonobo.Git.Server/Security/EFRepositoryPermissionService.cs
@@ -15,13 +15,24 @@ namespace Bonobo.Git.Server.Security
             {
                 username = username.ToLowerInvariant();
                 var user = database.Users.FirstOrDefault(i => i.Username == username);
-                var repository = database.Repositories.FirstOrDefault(i => i.Name == project);
-                if (user != null && repository != null)
+                if (user == null)
                 {
-                    if (user.Roles.FirstOrDefault(i => i.Name == Definitions.Roles.Administrator) != null
-                     || user.Repositories.FirstOrDefault(i => i.Name == project) != null
-                     || user.AdministratedRepositories.FirstOrDefault(i => i.Name == project) != null
-                     || user.Teams.Select(i => i.Name).FirstOrDefault(t => repository.Teams.Select(i => i.Name).Contains(t)) != null)
+                    // If we don't know the user, then we can't say they have permission
+                    return false;
+                }
+
+                if (user.Roles.FirstOrDefault(i => i.Name == Definitions.Roles.Administrator) != null)
+                {
+                    // This user is an admin, so they always have permission, regardless of the repository
+                    return true;
+                }
+
+                var repository = database.Repositories.FirstOrDefault(i => i.Name == project);
+                if (repository != null)
+                {
+                    if (user.Repositories.FirstOrDefault(i => i.Name == project) != null
+                    || user.AdministratedRepositories.FirstOrDefault(i => i.Name == project) != null
+                    || user.Teams.Select(i => i.Name).FirstOrDefault(t => repository.Teams.Select(i => i.Name).Contains(t)) != null)
                     {
                         return true;
                     }

--- a/Bonobo.Git.Server/Views/Settings/Index.cshtml
+++ b/Bonobo.Git.Server/Views/Settings/Index.cshtml
@@ -48,6 +48,7 @@
         <div class="pure-controls">
             <label for="AllowAnonymousRegistration" class="pure-checkbox">@Html.CheckBoxFor(m => m.AllowAnonymousRegistration) @Model.GetType().GetDisplayValue("AllowAnonymousRegistration") <i class="fa fa-info-circle" title="@Resources.Settings_Global_AllowAnonymousRegistration_Hint"></i></label>  
             <label for="AllowUserRepositoryCreation" class="pure-checkbox">@Html.CheckBoxFor(m => m.AllowUserRepositoryCreation) @Model.GetType().GetDisplayValue("AllowUserRepositoryCreation") <i class="fa fa-info-circle" title="@Resources.Settings_Global_AllowUserRepositoryCreation_Hint"></i></label>            
+            <label for="AllowPushToCreate" class="pure-checkbox">@Html.CheckBoxFor(m => m.AllowPushToCreate) @Model.GetType().GetDisplayValue("AllowPushToCreate") <i class="fa fa-info-circle" title="@Resources.Settings_Global_AllowPushToCreate_Hint"></i></label>
             <label for="AllowAnonymousPush" class="pure-checkbox">@Html.CheckBoxFor(m => m.AllowAnonymousPush) @Model.GetType().GetDisplayValue("AllowAnonymousPush")</label>
             <label for="IsCommitAuthorAvatarVisible" class="pure-checkbox">@Html.CheckBoxFor(m => m.IsCommitAuthorAvatarVisible) @Model.GetType().GetDisplayValue("IsCommitAuthorAvatarVisible")</label>
         </div>


### PR DESCRIPTION
Resolves #376.  I made it an option in user config, so it's not available by default.  At present, only Admins can push a new repo.  

I don't really know if this is a good idea or not, but it does allow automated creation of repos from the client, which is apparently what the OP on #376 wanted.
