### PR TITLE
Add Diagnostics page

### DIFF
--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -267,6 +267,7 @@
     <Compile Include="Attributes\RepositoryNameNormalizerAttribute.cs" />
     <Compile Include="Configuration\ActiveDirectorySettings.cs" />
     <Compile Include="Configuration\AuthenticationSettings.cs" />
+    <Compile Include="Configuration\DiagnosticReporter.cs" />
     <Compile Include="Configuration\FederationSettings.cs" />
     <Compile Include="Data\ADBackend.cs" />
     <Compile Include="Data\ADBackendStore.cs" />

--- a/Bonobo.Git.Server/Configuration/DiagnosticReporter.cs
+++ b/Bonobo.Git.Server/Configuration/DiagnosticReporter.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.Configuration;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Web.Hosting;
+using Bonobo.Git.Server.Data;
+using Bonobo.Git.Server.Security;
+
+namespace Bonobo.Git.Server.Configuration
+{
+    /// <summary>
+    /// This class can produce a textual diagnostic report of Bonobo's configuration
+    /// The idea is to give a one-shot collection of everything which might be needed to help diagnose problems people are having
+    /// It's written to be incredible defensive about all the checks it does, so that if things are misconfigured
+    /// we can still get a complete report
+    /// </summary>
+    public class DiagnosticReporter
+    {
+        private readonly StringBuilder _report = new StringBuilder();
+        private readonly UserConfiguration _userConfig = UserConfiguration.Current;
+
+        public string GetVerificationReport()
+        {
+            RunReport();
+            return _report.ToString();
+        }
+
+        private void RunReport()
+        {
+            DumpAppSettings();
+            CheckUserConfigurationFile();
+            CheckRepositoryDirectory();
+            CheckGitSettings();
+            CheckFederatedAuth();
+            CheckADMembership();
+            CheckInternalMembership();
+            ExceptionLog();
+        }
+
+        
+        private void DumpAppSettings()
+        {
+            _report.AppendLine("Web.Config AppSettings");
+            foreach (string key in ConfigurationManager.AppSettings)
+            {
+                QuotedReport("AppSettings."+key, ConfigurationManager.AppSettings[key]);
+            }
+        }
+
+        private void CheckUserConfigurationFile()
+        {
+            _report.AppendLine("User Configuration:");
+            var configFile = MapPath(AppSetting("UserConfiguration"));
+            QuotedReport("User Config File", configFile);
+            SafelyReport("User config readable", () => !String.IsNullOrEmpty(File.ReadAllText(configFile)));
+        }
+
+        private void CheckRepositoryDirectory()
+        {
+            _report.AppendLine("Repo Directory");
+            QuotedReport("Configured repo path", _userConfig.RepositoryPath);
+            QuotedReport("Effective repo path", _userConfig.Repositories);
+            SafelyReport("Repo folder exists", () => Directory.Exists(_userConfig.Repositories));
+        }
+
+        private void CheckGitSettings()
+        {
+            _report.AppendLine("Git Exe");
+            var gitPath = MapPath(AppSetting("GitPath"));
+            QuotedReport("Git path", gitPath);
+            SafelyReport("Git.exe exists", () => File.Exists(gitPath));
+        }
+
+        private void CheckFederatedAuth()
+        {
+            _report.AppendLine("Federated Authentication");
+            if (AppSetting("AuthenticationProvider") == "Federation")
+            {
+                SafelyReport("Metadata available", () =>
+                {
+                    WebClient client = new WebClient();
+                    var metadata = client.DownloadString(AppSetting("FederationMetadataAddress"));
+                    return !String.IsNullOrWhiteSpace(metadata);
+                });
+
+            }
+            else
+            {
+                Report("Not Enabled", "");
+            }
+        }
+
+        private void CheckADMembership()
+        {
+            _report.AppendLine("Active Directory");
+
+            if (AppSetting("MembershipService") == "ActiveDirectory")
+            {
+                SafelyReport("Backand folder exists", () => Directory.Exists(MapPath(AppSetting("ActiveDirectoryBackendPath"))));
+
+                var ad = ADBackend.Instance;
+                SafelyReport("Users", () => String.Join(",", ad.Users.Select(user => user.Name)));
+
+                _report.AppendLine("AD Teams");
+                SafelyRun(() =>
+                {
+                    foreach (var item in ad.Teams)
+                    {
+                        var thisTeam = item;
+                        SafelyReport(item.Name, () => String.Join(",", thisTeam.Members.Select(member => member.Name)));
+                    }
+                });
+                _report.AppendLine("AD Roles");
+                SafelyRun(() =>
+                {
+                    foreach (var item in ad.Roles)
+                    {
+                        var thisRole = item;
+                        SafelyReport(item.Name, () => String.Join(",", thisRole.Members));
+                    }
+                });
+            }
+            else
+            {
+                Report("Not Enabled");
+            }
+        }
+
+        private void CheckInternalMembership()
+        {
+            _report.AppendLine("Internal Membership");
+
+            if (AppSetting("MembershipService") == "Internal")
+            {
+                SafelyReport("Users", () => String.Join(",", new EFMembershipService().GetAllUsers().Select(member => member.Name)));
+            }
+            else
+            {
+                Report("Not Enabled");
+            }
+        }
+
+        /// <summary>
+        /// Append the last 10K of the exception log to the report
+        /// </summary>
+        private void ExceptionLog()
+        {
+            _report.AppendLine("Exception Log");
+            SafelyRun(() =>
+            {
+                var loggingListener = Trace.Listeners.OfType<TextWriterTraceListener>().FirstOrDefault();
+                if (loggingListener != null)
+                {
+                    var writer = loggingListener.Writer as StreamWriter;
+                    if (writer != null)
+                    {
+                        var fileStream = writer.BaseStream as FileStream;
+                        if (fileStream != null)
+                        {
+                            SafelyReport("LogFileName: ", () => fileStream.Name);
+                            var chunkSize = 10000;
+                            var length = new FileInfo(fileStream.Name).Length;
+                            Report("Log File total length", length);
+
+                            var startingPoint = Math.Max(0, length - chunkSize);
+                            Report("Starting log dump from ", startingPoint);
+
+                            using (var logText = File.Open(fileStream.Name, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                            {
+                                logText.Seek(startingPoint, SeekOrigin.Begin);
+                                var reader = new StreamReader(logText);
+                                _report.AppendLine(reader.ReadToEnd());
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        private void SafelyRun(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                Report("Diag error", FormatException(ex));
+            }
+        }
+
+        private void SafelyReport(string tag, Func<object> func)
+        {
+            try
+            {
+                object result = func();
+                if (result is bool)
+                {
+                    if ((bool)result)
+                    {
+                        Report(tag, "OK");
+                    }
+                    else
+                    {
+                        Report(tag, "FAIL");
+                    }
+                }
+                else
+                {
+                    Report(tag, result.ToString());
+                }
+            }
+            catch (Exception ex)
+            {
+                Report(tag, FormatException(ex));
+            }
+        }
+
+        private string MapPath(string path)
+        {
+            return Path.IsPathRooted(path) ? path : HostingEnvironment.MapPath(path);
+        }
+
+        private string AppSetting(string name)
+        {
+            return ConfigurationManager.AppSettings[name];
+        }
+
+        private static string FormatException(Exception ex)
+        {
+            return "EXCEPTION: " + ex.ToString().Replace("\r\n", "***");
+        }
+
+        private void Report(string tag, object value = null)
+        {
+            if (value != null)
+            {
+                _report.AppendFormat("--{0}: {1}" + Environment.NewLine, tag, value);
+            }
+            else
+            {
+                _report.AppendLine("--" + tag);
+            }
+        }
+
+        private void QuotedReport(string tag, object value)
+        {
+            Report(tag, "'"+value+"'");
+        }
+    }
+}
+

--- a/Bonobo.Git.Server/Controllers/HomeController.cs
+++ b/Bonobo.Git.Server/Controllers/HomeController.cs
@@ -9,6 +9,7 @@ using System.Web.Caching;
 using System.Web.Mvc;
 
 using Bonobo.Git.Server.App_GlobalResources;
+using Bonobo.Git.Server.Configuration;
 using Bonobo.Git.Server.Data;
 using Bonobo.Git.Server.Helpers;
 using Bonobo.Git.Server.Models;
@@ -178,6 +179,19 @@ namespace Bonobo.Git.Server.Controllers
         {
             Session["Culture"] = new CultureInfo(lang);
             return Redirect(returnUrl);
+        }
+
+        public ActionResult Diagnostics()
+        {
+            if (Request.IsLocal)
+            {
+                var verifier = new DiagnosticReporter();
+                return Content(verifier.GetVerificationReport(), "text/plain", Encoding.UTF8);
+            }
+            else
+            {
+                return Content("You can only run the diagnostics locally to the server");
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds a page /Home/Diagnostics (which is only available when run locally).

This contains a report of lots of details about the configuration (both WebConfig and UserConfig), plus the last 10K of the log file.

The idea would be that this could be a help when people report issues, many of which are configuration based or can be diagnosed by reference to the log.

Obviously dumping chunks of config is a potential security issue, but I feel this is suitably mitigated by the IsLocal check - by intention we DON'T want to use any kind of authentication/authorization, because we might be trying to diagnose problems with them.

An alternative to actually just returning the data as the page would be to write the report to somewhere on the machine (app_data probably), which would doubly-verify that someone had local access to the server.

Thoughts?