### PR TITLE
Change claims names to be more standard

### DIFF
--- a/Bonobo.Git.Server/Extensions/UserExtensions.cs
+++ b/Bonobo.Git.Server/Extensions/UserExtensions.cs
@@ -8,7 +8,7 @@ namespace Bonobo.Git.Server
 {
     public static class UserExtensions
     {
-        public static string GetClaim(this IPrincipal user, string claimName)
+        static string GetClaimValue(this IPrincipal user, string claimName)
         {
             try
             {
@@ -24,30 +24,59 @@ namespace Bonobo.Git.Server
             }
             catch(Exception ex)
             {
-                Trace.TraceError("GetClaim Exception " + ex);
+                Trace.TraceError("GetClaimValue Exception " + ex);
             }
             return null;
         }
 
         public static Guid Id(this IPrincipal user)
         {
-            string id = user.GetClaim(ClaimTypes.Upn);
-            return id != null ? Guid.Parse(id) : Guid.Empty;
+            string id = user.GetClaimValue(ClaimTypes.NameIdentifier);
+            Guid result;
+            if (Guid.TryParse(id, out result))
+            {
+                // It's a normal string Guid
+                return result;
+            }
+            else if (String.IsNullOrEmpty(id))
+            {
+                // I think this is a disaster if we don't have this claim and we should probably throw an exception here
+                // But anyway, for now I'm going to return Guid.Empty, and someone else can suffer later
+                // I'm going to log it, so that when they have a NullReferenceException later, they'll be able to see that
+                // this was a precursor
+                Trace.TraceError("User did not have NameIdentififer claim!!!");
+                return Guid.Empty;
+            }
+            else
+            {
+                try
+                {
+                    // We might be a ADFS-style Guid is which a base64 string
+                    // If this fails, we'll get a FormatException thrown anyway
+                    return new Guid(Convert.FromBase64String(id));
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceError("Could not parse id '{0}' from NameIdentifier claim: {1}", id, ex.Message);
+                    return Guid.Empty;
+                }
+            }
         }
 
         public static string Username(this IPrincipal user)
         {
-            return user.GetClaim(ClaimTypes.NameIdentifier);
+            // We can tolerate the username being in either Upn or Name
+            return user.GetClaimValue(ClaimTypes.Name) ?? user.GetClaimValue(ClaimTypes.Upn);
         }
 
-        public static string Name(this IPrincipal user)
+        public static string DisplayName(this IPrincipal user)
         {
-            return user.GetClaim(ClaimTypes.Name);
+            return string.Format("{0} {1}", user.GetClaimValue(ClaimTypes.GivenName), user.GetClaimValue(ClaimTypes.Surname));
         }
 
         public static bool IsWindowsAuthenticated(this IPrincipal user)
         {
-            string authenticationMethod = user.GetClaim(ClaimTypes.AuthenticationMethod);
+            string authenticationMethod = user.GetClaimValue(ClaimTypes.AuthenticationMethod);
             return !String.IsNullOrEmpty(authenticationMethod) && authenticationMethod.Equals("Windows", StringComparison.OrdinalIgnoreCase);
         }
 

--- a/Bonobo.Git.Server/Owin/WindowsAuthenticationHandler.cs
+++ b/Bonobo.Git.Server/Owin/WindowsAuthenticationHandler.cs
@@ -55,10 +55,10 @@ namespace Bonobo.Git.Server.Owin.Windows
 
                                 ClaimsIdentity identity = new ClaimsIdentity(Options.SignInAsAuthenticationType);
                                 List<Claim> result = new List<Claim>();
-                                result.Add(new Claim(ClaimTypes.Name, adUser.GivenName));
+                                result.Add(new Claim(ClaimTypes.GivenName, adUser.GivenName));
                                 result.Add(new Claim(ClaimTypes.Surname, adUser.Surname));
-                                result.Add(new Claim(ClaimTypes.Upn, adUser.Guid.ToString()));
-                                result.Add(new Claim(ClaimTypes.NameIdentifier, handshake.AuthenticatedUsername));
+                                result.Add(new Claim(ClaimTypes.NameIdentifier, adUser.Guid.ToString()));
+                                result.Add(new Claim(ClaimTypes.Name, handshake.AuthenticatedUsername));
                                 result.Add(new Claim(ClaimTypes.Email, adUser.EmailAddress));
                                 result.Add(new Claim(ClaimTypes.Role, Definitions.Roles.Administrator));
                                 result.Add(new Claim(ClaimTypes.Role, "Administrator"));

--- a/Bonobo.Git.Server/Security/AuthenticationProvider.cs
+++ b/Bonobo.Git.Server/Security/AuthenticationProvider.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Claims;
+using System.Linq;
 
 using Bonobo.Git.Server.Models;
 
@@ -31,9 +31,10 @@ namespace Bonobo.Git.Server.Security
             if (user != null)
             {
                 result = new List<Claim>();
-                result.Add(new Claim(ClaimTypes.Name, user.DisplayName));
-                result.Add(new Claim(ClaimTypes.Upn, user.Id.ToString()));
-                result.Add(new Claim(ClaimTypes.NameIdentifier, user.Username));
+                result.Add(new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()));
+                result.Add(new Claim(ClaimTypes.Name, user.Username));
+                result.Add(new Claim(ClaimTypes.GivenName, user.GivenName));
+                result.Add(new Claim(ClaimTypes.Surname, user.Surname));
                 result.Add(new Claim(ClaimTypes.Email, user.Email));
                 result.Add(new Claim(ClaimTypes.Role, Definitions.Roles.Member));
                 result.AddRange(RoleProvider.GetRolesForUser(user.Id).Select(x => new Claim(ClaimTypes.Role, x)));

--- a/Bonobo.Git.Server/Views/Shared/_Layout.cshtml
+++ b/Bonobo.Git.Server/Views/Shared/_Layout.cshtml
@@ -33,7 +33,7 @@
                     }
                     @if (Request.IsAuthenticated)
                     {
-                        <li class="separator"><a href="@Url.Action("Edit", "Account", new { id = User.Id() })"><i class="fa fa-male"></i> @User.Name()</a></li>
+                        <li class="separator"><a href="@Url.Action("Edit", "Account", new { id = User.Id() })"><i class="fa fa-male"></i> @User.DisplayName()</a></li>
                         if (!User.IsWindowsAuthenticated())
                         {
                             <li><a href="@Url.Action("LogOff", "Home")"><i class="fa fa-sign-out"></i> @Resources.Layout_LogOff</a></li>


### PR DESCRIPTION
This is a proposal to change the claims names we use, to make them slightly more standard, and allow more straightforward integration with ADFS, (and hopefully other external login systems should we ever offer them.)

This PR uses the following claims:

* **Name** = Username (unique in the membership database)
* **Upn** (UserPrincipleName) = Alternative location for username - we don't set this claim, but if Name isn't set, we'll look here for a username instead.  
* **NameIdentifier** - Guid ID for user.  We can accept this being either a string Guid, or being a base64 encoding of a Guid, which is what the ADFS ObjectGuid is.
* **GivenName**, **Surname**, **Email** - As you'd expect
* **Role** - Unaffected

This is based on work done for #368 with @stupiduglyfool, though it's not exactly what he's been testing.  Prior to these changes, he had to have a rather complex an un-intuitive mapping of ADFS claims to Bonobo claims, and a scripted Guid translation.  With this change, it should be much simpler.

Within Bonobo, it doesn't matter what claims we use, because we're packing stuff in and out of the claims identity ourselves anyway - this is just to help with other services which provide claims information externally, and to avoid unpleasant surprises like #471.

Thoughts...?

PS I don't like the 'DisplayName' hack which I put in - we could add a DisplayName claim, and thus pass it right through from AD/ADFS rather than constructing it ourselves, which is bound to risk internationalisation problems, etc.   It's actually only used for the heading text at the top of the page.