### PR TITLE
Cause and then fix #496

### DIFF
--- a/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
+++ b/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
@@ -57,11 +57,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Bonobo.Git.Server.Test/MembershipTests/EFTests/SqlServerTestConnection.cs
+++ b/Bonobo.Git.Server.Test/MembershipTests/EFTests/SqlServerTestConnection.cs
@@ -81,8 +81,9 @@ namespace Bonobo.Git.Server.Test.MembershipTests.EFTests
                     _databaseName);
                 cmd.ExecuteNonQuery();*/
 
-                var cmd2 = connection.CreateCommand();
-                cmd2.CommandText = string.Format(@"
+                using (var cmd2 = connection.CreateCommand())
+                {
+                    cmd2.CommandText = string.Format(@"
 
                     DECLARE @FILENAME AS VARCHAR(255)
                     SET @FILENAME = CONVERT(VARCHAR(255), '{1}');
@@ -93,8 +94,9 @@ namespace Bonobo.Git.Server.Test.MembershipTests.EFTests
 		                SIZE = 5MB, 
 		                MAXSIZE = 10MB, 
 		                FILEGROWTH = 5MB )')",
-                    _databaseName, fileName);
-                cmd2.ExecuteNonQuery();
+                        _databaseName, fileName);
+                    cmd2.ExecuteNonQuery();
+                }
 
                 Exec(connection, string.Format(@"ALTER DATABASE [{0}] SET AUTO_CLOSE ON;", _databaseName));
 //                Exec(connection, string.Format(@"ALTER DATABASE [{0}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;", _databaseName));
@@ -103,9 +105,11 @@ namespace Bonobo.Git.Server.Test.MembershipTests.EFTests
 
         private void Exec(SqlConnection connection, string commandText)
         {
-            var cmd = connection.CreateCommand();
-            cmd.CommandText = commandText;
-            cmd.ExecuteNonQuery();
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandText = commandText;
+                cmd.ExecuteNonQuery();
+            }
         }
 
         public void Dispose()

--- a/Bonobo.Git.Server.Test/app.config
+++ b/Bonobo.Git.Server.Test/app.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -50,6 +50,10 @@
         <assemblyIdentity name="System.Data.SQLite" publicKeyToken="db937bc2d44ff139" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.0.98.0" newVersion="1.0.98.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>
@@ -59,9 +63,9 @@
       </parameters>
     </defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
       <provider invariantName="System.Data.SQLite" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
       <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
   <system.data>

--- a/Bonobo.Git.Server.Test/packages.config
+++ b/Bonobo.Git.Server.Test/packages.config
@@ -1,10 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EntityFramework" version="6.0.0" targetFramework="net45" />
-  <package id="System.Data.SQLite" version="1.0.99.0" targetFramework="net45" />
-  <package id="System.Data.SQLite.Core" version="1.0.99.0" targetFramework="net45" />
-  <package id="System.Data.SQLite.EF6" version="1.0.99.0" targetFramework="net45" />
-  <package id="System.Data.SQLite.Linq" version="1.0.99.0" targetFramework="net45" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.Mvc.Futures" version="5.0.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net451" />
@@ -15,4 +11,8 @@
   <package id="Selenium.WebDriver.ChromeDriver" version="2.20.0.0" targetFramework="net451" />
   <package id="Selenium.WebDriver.IEDriver" version="2.48.0.0" targetFramework="net451" />
   <package id="SpecsFor.Mvc" version="4.7.1" targetFramework="net451" />
+  <package id="System.Data.SQLite" version="1.0.99.0" targetFramework="net45" />
+  <package id="System.Data.SQLite.Core" version="1.0.99.0" targetFramework="net45" />
+  <package id="System.Data.SQLite.EF6" version="1.0.99.0" targetFramework="net45" />
+  <package id="System.Data.SQLite.Linq" version="1.0.99.0" targetFramework="net45" />
 </packages>

--- a/Bonobo.Git.Server/Data/Update/AutomaticUpdater.cs
+++ b/Bonobo.Git.Server/Data/Update/AutomaticUpdater.cs
@@ -49,27 +49,21 @@ namespace Bonobo.Git.Server.Data.Update
                     }
                 }
 
-                try
+                if (!string.IsNullOrEmpty(item.Command))
                 {
-                    ctxAdapter.ObjectContext.ExecuteStoreCommand(item.Command);
+                    try
+                    {
+                        ctxAdapter.ObjectContext.ExecuteStoreCommand(item.Command);
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.TraceError("Exception while processing upgrade script {0}\r\n{1}", item.Command, ex);
+                        throw;
+                    }
                 }
-                catch(Exception ex)
-                {
-                    Trace.TraceError("Exception while processing upgrade script {0}\r\n{1}", item.Command, ex);
-                    throw;
-                }
-            }
-            // the current pattern does not cut it anymore for adding the guid column
 
-            if (connectiontype.Equals("SQLiteConnection"))
-            {
-                new Sqlite.AddGuidColumn(ctx);
+                item.CodeAction(ctx);
             }
-            else
-            {
-                new SqlServer.AddGuidColumn(ctx);
-            }
-
         }
     }
 }

--- a/Bonobo.Git.Server/Data/Update/IUpdateScript.cs
+++ b/Bonobo.Git.Server/Data/Update/IUpdateScript.cs
@@ -1,13 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
+﻿
 namespace Bonobo.Git.Server.Data.Update
 {
+    /// <summary>
+    /// When running an update script, the system will first test the Precondition (if it's present)
+    /// Assuming the precondition doesn't stop execution, the Command will then be run (if it's present)
+    /// Finally, the CodeAction will be called to perform steps which cannot be done by a plain SQL command
+    /// </summary>
     public interface IUpdateScript
     {
+        /// <summary>
+        /// Optional SQL command to execute (pass null to ignore)
+        /// </summary>
         string Command { get; }
+        /// <summary>
+        /// Null always execute this item, or SQL command returning non-zero to execute
+        /// </summary>
         string Precondition { get; }
+        /// <summary>
+        /// A code-based action, if SQL Command is inadequate
+        /// </summary>
+        void CodeAction(BonoboGitServerContext context);
     }
 }

--- a/Bonobo.Git.Server/Data/Update/SqlServer/AddAuditPushUser.cs
+++ b/Bonobo.Git.Server/Data/Update/SqlServer/AddAuditPushUser.cs
@@ -32,5 +32,7 @@ namespace Bonobo.Git.Server.Data.Update.SqlServer
 ";
             }
         }
+
+        public void CodeAction(BonoboGitServerContext context) { }
     }
 }

--- a/Bonobo.Git.Server/Data/Update/SqlServer/AddGroup.cs
+++ b/Bonobo.Git.Server/Data/Update/SqlServer/AddGroup.cs
@@ -1,4 +1,6 @@
-﻿namespace Bonobo.Git.Server.Data.Update.SqlServer
+﻿using System;
+
+namespace Bonobo.Git.Server.Data.Update.SqlServer
 {
     public class AddGroup : IUpdateScript
     {
@@ -22,5 +24,8 @@
 ";
             }
         }
+
+        public void CodeAction(BonoboGitServerContext context) { }
+
     }
 }

--- a/Bonobo.Git.Server/Data/Update/SqlServer/AddRepositoryLogo.cs
+++ b/Bonobo.Git.Server/Data/Update/SqlServer/AddRepositoryLogo.cs
@@ -1,4 +1,6 @@
-﻿namespace Bonobo.Git.Server.Data.Update.SqlServer
+﻿using System;
+
+namespace Bonobo.Git.Server.Data.Update.SqlServer
 {
     public class AddRepositoryLogo : IUpdateScript
     {
@@ -22,5 +24,8 @@
 ";
             }
         }
+
+        public void CodeAction(BonoboGitServerContext context) { }
+
     }
 }

--- a/Bonobo.Git.Server/Data/Update/SqlServer/InitialCreateScript.cs
+++ b/Bonobo.Git.Server/Data/Update/SqlServer/InitialCreateScript.cs
@@ -1,4 +1,6 @@
-﻿namespace Bonobo.Git.Server.Data.Update.SqlServer
+﻿using System;
+
+namespace Bonobo.Git.Server.Data.Update.SqlServer
 {
     public class InitialCreateScript : IUpdateScript
     {
@@ -110,5 +112,8 @@
         {
             get { return null; }
         }
+
+        public void CodeAction(BonoboGitServerContext context) { }
+
     }
 }

--- a/Bonobo.Git.Server/Data/Update/SqlServer/InsertDefaultData.cs
+++ b/Bonobo.Git.Server/Data/Update/SqlServer/InsertDefaultData.cs
@@ -1,24 +1,25 @@
-﻿namespace Bonobo.Git.Server.Data.Update.SqlServer
+﻿using System;
+
+namespace Bonobo.Git.Server.Data.Update.SqlServer
 {
     public class InsertDefaultData : IUpdateScript
     {
         public string Command
         {
-            get
-            {
-                return @"
+            get { return @"
 
                     INSERT INTO [Role] ([Name], [Description]) VALUES ('Administrator','System administrator');
                     INSERT INTO [User] ([Name], [Surname], [Username], [Password], [Email]) VALUES ('admin', '', 'admin', '0CC52C6751CC92916C138D8D714F003486BF8516933815DFC11D6C3E36894BFA044F97651E1F3EEBA26CDA928FB32DE0869F6ACFB787D5A33DACBA76D34473A3', '');
                     INSERT INTO [UserRole_InRole] ([User_Username], [Role_Name]) VALUES ('admin', 'Administrator');
 
-                    ";
-            }
+                    "; }
         }
 
         public string Precondition
         {
             get { return @"SELECT case when count(*) = 0 then 1 ELSE 0 END FROM [User]"; }
         }
+
+        public void CodeAction(BonoboGitServerContext context) { }
     }
 }

--- a/Bonobo.Git.Server/Data/Update/Sqlite/AddAuditPushUser.cs
+++ b/Bonobo.Git.Server/Data/Update/Sqlite/AddAuditPushUser.cs
@@ -1,4 +1,6 @@
-﻿namespace Bonobo.Git.Server.Data.Update.Sqlite
+﻿using System;
+
+namespace Bonobo.Git.Server.Data.Update.Sqlite
 {
     public class AddAuditPushUser : IUpdateScript
     {
@@ -20,5 +22,8 @@
                 return "SELECT Count(AuditPushUser) = -1 FROM [Repository]";
             }
         }
+
+        public void CodeAction(BonoboGitServerContext context) {}
+
     }
 }

--- a/Bonobo.Git.Server/Data/Update/Sqlite/AddGroup.cs
+++ b/Bonobo.Git.Server/Data/Update/Sqlite/AddGroup.cs
@@ -1,4 +1,6 @@
-﻿namespace Bonobo.Git.Server.Data.Update.Sqlite
+﻿using System;
+
+namespace Bonobo.Git.Server.Data.Update.Sqlite
 {
     public class AddGroup : IUpdateScript
     {
@@ -17,5 +19,8 @@
                 return "SELECT Count([Group]) = -1 FROM Repository";
             }
         }
+
+        public void CodeAction(BonoboGitServerContext context) { }
+
     }
 }

--- a/Bonobo.Git.Server/Data/Update/Sqlite/AddGuidColumn.cs
+++ b/Bonobo.Git.Server/Data/Update/Sqlite/AddGuidColumn.cs
@@ -8,15 +8,18 @@ using System.Data.SQLite;
 
 namespace Bonobo.Git.Server.Data.Update.Sqlite
 {
-    public class AddGuidColumn
+    public class AddGuidColumn : IUpdateScript
     {
-        readonly IAuthenticationProvider AuthProvider;
-        readonly Database _db;
+        private readonly IAuthenticationProvider AuthProvider;
+        private Database _db;
 
-        public AddGuidColumn(BonoboGitServerContext context)
+        public AddGuidColumn()
         {
             AuthProvider = DependencyResolver.Current.GetService<IAuthenticationProvider>();
+        }
 
+        public void CodeAction(BonoboGitServerContext context)
+        {
             _db = context.Database;
 
             if (UpgradeHasAlreadyBeenRun())
@@ -415,5 +418,8 @@ namespace Bonobo.Git.Server.Data.Update.Sqlite
 
             ");
         }
+
+        public string Command { get { return null; } }
+        public string Precondition { get { return null; } }
     }
 }

--- a/Bonobo.Git.Server/Data/Update/Sqlite/AddRepositoryLogo.cs
+++ b/Bonobo.Git.Server/Data/Update/Sqlite/AddRepositoryLogo.cs
@@ -1,4 +1,6 @@
-﻿namespace Bonobo.Git.Server.Data.Update.Sqlite
+﻿using System;
+
+namespace Bonobo.Git.Server.Data.Update.Sqlite
 {
     public class AddRepositoryLogo : IUpdateScript
     {
@@ -17,5 +19,8 @@
                 return "SELECT Count([Logo]) = -1 FROM Repository";
             }
         }
+
+        public void CodeAction(BonoboGitServerContext context) { }
+
     }
 }

--- a/Bonobo.Git.Server/Data/Update/Sqlite/InitialCreateScript.cs
+++ b/Bonobo.Git.Server/Data/Update/Sqlite/InitialCreateScript.cs
@@ -1,4 +1,6 @@
 ﻿
+using System;
+
 namespace Bonobo.Git.Server.Data.Update.Sqlite
 {
     public class InitialCreateScript : IUpdateScript
@@ -86,5 +88,7 @@ namespace Bonobo.Git.Server.Data.Update.Sqlite
         {
             get { return null; }
         }
+
+        public void CodeAction(BonoboGitServerContext context) { }
     }
 }

--- a/Bonobo.Git.Server/Data/Update/Sqlite/InsertDefaultData.cs
+++ b/Bonobo.Git.Server/Data/Update/Sqlite/InsertDefaultData.cs
@@ -24,5 +24,7 @@ namespace Bonobo.Git.Server.Data.Update.Sqlite
         {
             get { return @"SELECT Count(*) = 0 FROM [User]"; }
         }
+
+        public void CodeAction(BonoboGitServerContext context) { }
     }
 }

--- a/Bonobo.Git.Server/Data/Update/UpdateScriptRepository.cs
+++ b/Bonobo.Git.Server/Data/Update/UpdateScriptRepository.cs
@@ -20,7 +20,8 @@ namespace Bonobo.Git.Server.Data.Update
                         new UsernamesToLower(),
                         new Sqlite.AddAuditPushUser(),
                         new Sqlite.AddGroup(),
-                        new Sqlite.AddRepositoryLogo()
+                        new Sqlite.AddRepositoryLogo(),
+                        new Sqlite.AddGuidColumn()
                     };
                 case "SqlConnection":
                     return new List<IUpdateScript>
@@ -30,7 +31,8 @@ namespace Bonobo.Git.Server.Data.Update
                         new UsernamesToLower(),
                         new SqlServer.AddAuditPushUser(),
                         new SqlServer.AddGroup(),
-                        new SqlServer.AddRepositoryLogo()
+                        new SqlServer.AddRepositoryLogo(),
+                        new SqlServer.AddGuidColumn()
                     };
                 default:
                     throw new NotImplementedException(string.Format("The provider '{0}' is not supported yet", sqlProvider));

--- a/Bonobo.Git.Server/Data/Update/UsernamesToLower.cs
+++ b/Bonobo.Git.Server/Data/Update/UsernamesToLower.cs
@@ -1,4 +1,6 @@
-﻿namespace Bonobo.Git.Server.Data.Update
+﻿using System;
+
+namespace Bonobo.Git.Server.Data.Update
 {
     public class UsernamesToLower : IUpdateScript
     {
@@ -16,5 +18,8 @@
         {
             get { return null; }
         }
+
+        public void CodeAction(BonoboGitServerContext context) { }
+
     }
 }

--- a/Bonobo.Git.Server/Security/EFMembershipService.cs
+++ b/Bonobo.Git.Server/Security/EFMembershipService.cs
@@ -171,20 +171,18 @@ namespace Bonobo.Git.Server.Security
         {
             using (var db = CreateContext())
             {
-                foreach (var user in db.Users)
+                var user = db.Users.FirstOrDefault(u => u.Id == id);
+                if (user != null)
                 {
-                    if (user.Id == id)
-                    {
-                        user.AdministratedRepositories.Clear();
-                        user.Roles.Clear();
-                        user.Repositories.Clear();
-                        user.Teams.Clear();
-                        db.Users.Remove(user);
-                        db.SaveChanges();
-                    }
+                    user.AdministratedRepositories.Clear();
+                    user.Roles.Clear();
+                    user.Repositories.Clear();
+                    user.Teams.Clear();
+                    db.Users.Remove(user);
+                    db.SaveChanges();
                 }
             }
-        }
+        } 
 
         private void SetPassword(User user, string password)
         {


### PR DESCRIPTION
Fixes #496 

Also reworks the database update mechanism so that code-based upgrades like AddGuidColumn fit in more smoothly with the other updates - and we can add things after it without trouble.