### PR TITLE
Fall back to Username if DisplayName cannot be formed

### DIFF
--- a/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
+++ b/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
@@ -175,6 +175,7 @@
     <Compile Include="UnitTests\PasswordServiceTest.cs" />
     <Compile Include="UnitTests\GitAuthorizeAttributeTest.cs" />
     <Compile Include="UnitTests\UserExtensionsTests.cs" />
+    <Compile Include="UnitTests\UserModelTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonobo.Git.Server\Bonobo.Git.Server.csproj">

--- a/Bonobo.Git.Server.Test/UnitTests/UserModelTest.cs
+++ b/Bonobo.Git.Server.Test/UnitTests/UserModelTest.cs
@@ -1,0 +1,31 @@
+﻿using Bonobo.Git.Server.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonobo.Git.Server.Test.UnitTests
+{
+    [TestClass]
+    public sealed class UserModelTest
+    {
+        [TestMethod]
+        public void DisplayNameFormation()
+        {
+            Assert.AreEqual("John Smith", new UserModel { GivenName = "John", Surname = "Smith" }.DisplayName);
+            Assert.AreEqual("John", new UserModel { GivenName = "John", Surname = null }.DisplayName);
+            Assert.AreEqual("John", new UserModel { GivenName = "John", Surname = "" }.DisplayName);
+            Assert.AreEqual("Smith", new UserModel { GivenName = null, Surname = "Smith" }.DisplayName);
+            Assert.AreEqual("Smith", new UserModel { GivenName = "", Surname = "Smith" }.DisplayName);
+            Assert.AreEqual("JohnSmith", new UserModel { Username="JohnSmith" }.DisplayName);
+        }
+
+        [TestMethod]
+        public void SortNameFormation()
+        {
+            Assert.AreEqual("SmithJohn", new UserModel { GivenName = "John", Surname = "Smith" }.SortName);
+            Assert.AreEqual("John", new UserModel { GivenName = "John", Surname = null }.SortName);
+            Assert.AreEqual("John", new UserModel { GivenName = "John", Surname = "" }.SortName);
+            Assert.AreEqual("Smith", new UserModel { GivenName = null, Surname = "Smith" }.SortName);
+            Assert.AreEqual("Smith", new UserModel { GivenName = "", Surname = "Smith" }.SortName);
+            Assert.AreEqual("JohnSmith", new UserModel { Username = "JohnSmith" }.SortName);
+        }
+    }
+}

--- a/Bonobo.Git.Server/Models/AccountModels.cs
+++ b/Bonobo.Git.Server/Models/AccountModels.cs
@@ -39,13 +39,38 @@ namespace Bonobo.Git.Server.Models
         {
             get
             {
-                return String.Format("{0} {1}", GivenName, Surname);
+                var compositeName = String.Format("{0} {1}", GivenName, Surname).Trim();
+                if (String.IsNullOrEmpty(compositeName))
+                {
+                    // Return the username if we don't have a GivenName or Surname
+                    return Username;
+                }
+                else
+                {
+                    return compositeName;
+                }
             }
         }
 
         string INameProperty.Name
         {
             get { return Username; }
+        }
+
+        /// <summary>
+        /// This is the name we'd sort users by
+        /// </summary>
+        public string SortName
+        {
+            get
+            {
+                var compositeName = Surname + GivenName;
+                if (String.IsNullOrEmpty(compositeName))
+                {
+                    return Username;
+                }
+                return compositeName;
+            }
         }
     }
 


### PR DESCRIPTION
This is an uncontroversial, I think, change to DisplayName to make sure that if people don't have a Given/Surname set then they get the username shown rather than a blank.  Fixes one complaint in comments on #500, which I think is important for the next release, as blank Display Names are a bit of a disaster.

This also adds a 'SortName' which isn't used anywhere at present but could be used to sort the users by  (it's not intended for display)

