### PR TITLE
[RFC] Push to create

### DIFF
--- a/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
+++ b/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
@@ -144,6 +144,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="IntegrationTests\SharedLayoutTests.cs" />
+    <Compile Include="IntegrationTests\GitResult.cs" />
     <Compile Include="MembershipTests\ADTests\ADBackendStoreTest.cs" />
     <Compile Include="MembershipTests\ADTests\ADMembershipServiceTest.cs" />
     <Compile Include="MembershipTests\ADTests\ADMembershipServiceTestFacade.cs" />

--- a/Bonobo.Git.Server.Test/IntegrationTests/GitResult.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/GitResult.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Bonobo.Git.Server.Test.IntegrationTests
 {
@@ -29,21 +30,9 @@ namespace Bonobo.Git.Server.Test.IntegrationTests
 
         public void ErrorMustMatch(MsysgitResources.Definition resource, params object[] args)
         {
-            string matchString;
-            if (args.Length > 0)
-            {
-                matchString = string.Format(Resources[resource], args);
-            }
-            else
-            {
-                matchString = Resources[resource];
-            }
-            var expected = matchString.Trim();
+            var expected = string.Format(Resources[resource], args).Trim();
             var actual = StdErr.Trim();
-            if (expected != actual)
-            {
-                Assert.Fail("Git operation StdErr mismatch - expected '{0}', was '{1}'", expected, actual);
-            }
+            Assert.AreEqual(expected, actual, "Git operation StdErr mismatch");
         }
     }
 }

--- a/Bonobo.Git.Server.Test/IntegrationTests/GitResult.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/GitResult.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonobo.Git.Server.Test.IntegrationTests
+{
+    public class GitResult
+    {
+        public string StdErr { get; set; }
+        public string StdOut { get; set; }
+        public int ExitCode { get; set; }
+        public MsysgitResources Resources { get; set; }
+
+        public bool Succeeded
+        {
+            get { return ExitCode == 0; }
+        }
+
+        public bool AccessDenied
+        {
+            get { return !Succeeded && StdErr.Contains(Resources[MsysgitResources.Definition.AuthenticationFailedError]); }
+        }
+
+        public void ExpectSuccess()
+        {
+            if (!Succeeded)
+            {
+                Assert.Fail("Git operation failed with exit code {0}, stderr {1}", ExitCode, StdErr);
+            }
+        }
+
+        public void ErrorMustMatch(MsysgitResources.Definition resource, params object[] args)
+        {
+            string matchString;
+            if (args.Length > 0)
+            {
+                matchString = string.Format(Resources[resource], args);
+            }
+            else
+            {
+                matchString = Resources[resource];
+            }
+            var expected = matchString.Trim();
+            var actual = StdErr.Trim();
+            if (expected != actual)
+            {
+                Assert.Fail("Git operation StdErr mismatch - expected '{0}', was '{1}'", expected, actual);
+            }
+        }
+    }
+}

--- a/Bonobo.Git.Server.Test/IntegrationTests/MsysgitIntegrationTests.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/MsysgitIntegrationTests.cs
@@ -244,7 +244,23 @@ namespace Bonobo.Git.Server.Test.Integration.ClAndWeb
             });
         }
 
-        
+        [TestMethod, TestCategory(TestCategories.ClAndWebIntegrationTest)]
+        public void PushToCreateIsNotNormallyAllowed()
+        {
+            ForAllGits((git, resource) =>
+            {
+                // Create a repo locally
+                CreateIdentity(git);
+
+                Directory.CreateDirectory(RepositoryDirectory);
+                InitAndPushRepository(git, resource);
+
+
+//                DeleteRepository(repo_id);
+            });
+        }
+
+
         /// <summary>
         /// Helper to run a test for every installed Git instance
         /// </summary>
@@ -377,6 +393,15 @@ namespace Bonobo.Git.Server.Test.Integration.ClAndWeb
             RunGitOnRepo(git, "init");
             RunGitOnRepo(git, String.Format("remote add origin {0}", RepositoryUrlWithCredentials));
             var result = RunGitOnRepo(git, "pull origin master");
+
+            Assert.AreEqual(String.Format(resource[MsysgitResources.Definition.PullRepositoryError], RepositoryUrlWithoutCredentials), result.Item2);
+        }
+
+        private void InitAndPushRepository(string git, MsysgitResources resource)
+        {
+            RunGitOnRepo(git, "init");
+            RunGitOnRepo(git, String.Format("remote add origin {0}", RepositoryUrlWithCredentials));
+            var result = RunGitOnRepo(git, "push origin master");
 
             Assert.AreEqual(String.Format(resource[MsysgitResources.Definition.PullRepositoryError], RepositoryUrlWithoutCredentials), result.Item2);
         }

--- a/Bonobo.Git.Server.Test/IntegrationTests/MsysgitResources.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/MsysgitResources.cs
@@ -22,6 +22,8 @@ namespace Bonobo.Git.Server.Test
             CloneRepositoryError,
             PushBranchError,
             CloneRepositoryFailRequiresAuthError,
+            AuthenticationFailedError,
+            RepositoryNotFoundError
         }
 
 
@@ -51,6 +53,8 @@ namespace Bonobo.Git.Server.Test
                 { Definition.CloneRepositoryOutput, "Cloning into Integration...\r\n" },
                 { Definition.CloneRepositoryError,"" },
                 { Definition.PushBranchError, "To {0}\r\n * [new branch]      TestBranch -> TestBranch\r\n" },
+                { Definition.AuthenticationFailedError, "fatal: Authentication failed" },
+                { Definition.RepositoryNotFoundError, "fatal: repository '{0}/' not found" }
             };
 
             if (String.Equals(version, "1.7.8") 

--- a/Bonobo.Git.Server/App_GlobalResources/Resources.Designer.cs
+++ b/Bonobo.Git.Server/App_GlobalResources/Resources.Designer.cs
@@ -1926,6 +1926,24 @@ namespace Bonobo.Git.Server.App_GlobalResources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow push to create repositories.
+        /// </summary>
+        public static string Settings_Global_AllowPushToCreate {
+            get {
+                return ResourceManager.GetString("Settings_Global_AllowPushToCreate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If checkbox is checked, Administrators can push a new repository .
+        /// </summary>
+        public static string Settings_Global_AllowPushToCreate_Hint {
+            get {
+                return ResourceManager.GetString("Settings_Global_AllowPushToCreate_Hint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Allow user repository creation.
         /// </summary>
         public static string Settings_Global_AllowUserRepositoryCreation {

--- a/Bonobo.Git.Server/App_GlobalResources/Resources.resx
+++ b/Bonobo.Git.Server/App_GlobalResources/Resources.resx
@@ -682,6 +682,12 @@
   <data name="Settings_Global_AllowUserRepositoryCreation_Hint" xml:space="preserve">
     <value>If checkbox is unchecked, only administrators can create repositories.</value>
   </data>
+  <data name="Settings_Global_AllowPushToCreate" xml:space="preserve">
+    <value>Allow push to create repositories</value>
+  </data>
+  <data name="Settings_Global_AllowPushToCreate_Hint" xml:space="preserve">
+    <value>If checkbox is checked, Administrators can push a new repository </value>
+  </data>
   <data name="Delete_Back" xml:space="preserve">
     <value>Back</value>
   </data>

--- a/Bonobo.Git.Server/Configuration/UserConfiguration.cs
+++ b/Bonobo.Git.Server/Configuration/UserConfiguration.cs
@@ -16,6 +16,7 @@ namespace Bonobo.Git.Server.Configuration
         [XmlElementAttribute(ElementName = "Repositories")]
         public string RepositoryPath { get; set; }
         public bool AllowUserRepositoryCreation { get; set; }
+        public bool AllowPushToCreate { get; set; }
         public bool AllowAnonymousRegistration { get; set; }
         public string DefaultLanguage { get; set; }
         public string SiteTitle { get; set; }

--- a/Bonobo.Git.Server/Controllers/GitController.cs
+++ b/Bonobo.Git.Server/Controllers/GitController.cs
@@ -4,12 +4,14 @@ using System.IO;
 using System.Net;
 using System.Web.Mvc;
 using Bonobo.Git.Server.Configuration;
+using Bonobo.Git.Server.Data;
 using Bonobo.Git.Server.Git;
 using Bonobo.Git.Server.Git.GitService;
+using Bonobo.Git.Server.Models;
 using Bonobo.Git.Server.Security;
 using Ionic.Zlib;
-using LibGit2Sharp;
 using Microsoft.Practices.Unity;
+using Repository = LibGit2Sharp.Repository;
 
 namespace Bonobo.Git.Server.Controllers
 {
@@ -19,21 +21,39 @@ namespace Bonobo.Git.Server.Controllers
     {
         [Dependency]
         public IRepositoryPermissionService RepositoryPermissionService { get; set; }
-        
+
+        [Dependency]
+        public IRepositoryRepository RepositoryRepository { get; set; }
+
+        [Dependency]
+        public IMembershipService MembershipService { get; set; }
+
         [Dependency]
         public IGitService GitService { get; set; }
 
         public ActionResult SecureGetInfoRefs(String repositoryName, String service)
         {
-            if (!RepositoryIsValid(repositoryName))
-            {
-                return new HttpNotFoundResult();
-            }
-
             bool isPush = String.Equals("git-receive-pack", service, StringComparison.OrdinalIgnoreCase);
 
-            var requiredLevel = isPush ? RepositoryAccessLevel.Push : RepositoryAccessLevel.Pull;
+            if (!RepositoryIsValid(repositoryName))
+            {
+                // This isn't a real repo - but we might consider allowing creation
+                if (isPush && 
+                    UserConfiguration.Current.AllowPushToCreate && 
+                    RepositoryPermissionService.HasCreatePermission(User.Id()))
+                {
+                    if (!TryCreateOnPush(repositoryName))
+                    {
+                        return UnauthorizedResult();
+                    }
+                }
+                else
+                {
+                    return new HttpNotFoundResult();
+                }
+            }
 
+            var requiredLevel = isPush ? RepositoryAccessLevel.Push : RepositoryAccessLevel.Pull;
             if (RepositoryPermissionService.HasPermission(User.Id(), repositoryName, requiredLevel))
             {
                 return GetInfoRefs(repositoryName, service);
@@ -79,6 +99,36 @@ namespace Bonobo.Git.Server.Controllers
                 return UnauthorizedResult();
             }
         }
+
+        private bool TryCreateOnPush(string repositoryName)
+        {
+            DirectoryInfo directory = GetDirectoryInfo(repositoryName);
+            if (directory.Exists)
+            {
+                // We can't create a new repo - there's already a directory with that name
+                return false;
+            }
+            RepositoryModel repository = new RepositoryModel();
+            repository.Name = repositoryName;
+            if (!repository.NameIsValid)
+            {
+                // We don't like this name
+                return false;
+            }
+            var user = MembershipService.GetUserModel(User.Id());
+            repository.Description = "Auto-created by push for " + user.DisplayName;
+            repository.AnonymousAccess = false;
+            repository.Administrators = new[] {user};
+            if (!RepositoryRepository.Create(repository))
+            {
+                // We can't add this to the repo store
+                return false;
+            }
+
+            Repository.Init(Path.Combine(UserConfiguration.Current.Repositories, repository.Name), true);
+            return true;
+        }
+
 
         /// <summary>
         /// This is the action invoked if you browse to a .git URL

--- a/Bonobo.Git.Server/Controllers/GitController.cs
+++ b/Bonobo.Git.Server/Controllers/GitController.cs
@@ -38,10 +38,12 @@ namespace Bonobo.Git.Server.Controllers
             if (!RepositoryIsValid(repositoryName))
             {
                 // This isn't a real repo - but we might consider allowing creation
-                if (isPush && 
-                    UserConfiguration.Current.AllowPushToCreate && 
-                    RepositoryPermissionService.HasCreatePermission(User.Id()))
+                if (isPush && UserConfiguration.Current.AllowPushToCreate)
                 {
+                    if (!RepositoryPermissionService.HasCreatePermission(User.Id()))
+                    {
+                        return UnauthorizedResult();
+                    }
                     if (!TryCreateOnPush(repositoryName))
                     {
                         return UnauthorizedResult();

--- a/Bonobo.Git.Server/Controllers/SettingsController.cs
+++ b/Bonobo.Git.Server/Controllers/SettingsController.cs
@@ -24,6 +24,7 @@ namespace Bonobo.Git.Server.Controllers
                 RepositoryPath = UserConfiguration.Current.RepositoryPath,
                 AllowAnonymousRegistration = UserConfiguration.Current.AllowAnonymousRegistration,
                 AllowUserRepositoryCreation = UserConfiguration.Current.AllowUserRepositoryCreation,
+                AllowPushToCreate = UserConfiguration.Current.AllowPushToCreate,
                 DefaultLanguage = UserConfiguration.Current.DefaultLanguage,
                 SiteTitle = UserConfiguration.Current.SiteTitle,
                 SiteLogoUrl = UserConfiguration.Current.SiteLogoUrl,
@@ -50,6 +51,7 @@ namespace Bonobo.Git.Server.Controllers
                         UserConfiguration.Current.RepositoryPath = model.RepositoryPath;
                         UserConfiguration.Current.AllowAnonymousRegistration = model.AllowAnonymousRegistration;
                         UserConfiguration.Current.AllowUserRepositoryCreation = model.AllowUserRepositoryCreation;
+                        UserConfiguration.Current.AllowPushToCreate = model.AllowPushToCreate;
                         UserConfiguration.Current.DefaultLanguage = model.DefaultLanguage;
                         UserConfiguration.Current.SiteTitle = model.SiteTitle;
                         UserConfiguration.Current.SiteLogoUrl = model.SiteLogoUrl;

--- a/Bonobo.Git.Server/Models/SettingsModels.cs
+++ b/Bonobo.Git.Server/Models/SettingsModels.cs
@@ -18,6 +18,9 @@ namespace Bonobo.Git.Server.Models
         [Display(ResourceType = typeof(Resources), Name = "Settings_Global_AllowUserRepositoryCreation")]
         public bool AllowUserRepositoryCreation { get; set; }
 
+        [Display(ResourceType = typeof(Resources), Name = "Settings_Global_AllowPushToCreate")]
+        public bool AllowPushToCreate { get; set; }
+
         [Required(ErrorMessageResourceType = typeof(Resources), ErrorMessageResourceName = "Validation_Required")]
         [Display(ResourceType = typeof(Resources), Name = "Settings_Global_RepositoryPath")]
         public string RepositoryPath { get; set; }

--- a/Bonobo.Git.Server/Views/Settings/Index.cshtml
+++ b/Bonobo.Git.Server/Views/Settings/Index.cshtml
@@ -54,6 +54,7 @@
         <div class="pure-controls">
             <label for="AllowAnonymousRegistration" class="pure-checkbox">@Html.CheckBoxFor(m => m.AllowAnonymousRegistration) @Model.GetType().GetDisplayValue("AllowAnonymousRegistration") <i class="fa fa-info-circle" title="@Resources.Settings_Global_AllowAnonymousRegistration_Hint"></i></label>  
             <label for="AllowUserRepositoryCreation" class="pure-checkbox">@Html.CheckBoxFor(m => m.AllowUserRepositoryCreation) @Model.GetType().GetDisplayValue("AllowUserRepositoryCreation") <i class="fa fa-info-circle" title="@Resources.Settings_Global_AllowUserRepositoryCreation_Hint"></i></label>            
+            <label for="AllowPushToCreate" class="pure-checkbox">@Html.CheckBoxFor(m => m.AllowPushToCreate) @Model.GetType().GetDisplayValue("AllowPushToCreate") <i class="fa fa-info-circle" title="@Resources.Settings_Global_AllowPushToCreate_Hint"></i></label>
             <label for="AllowAnonymousPush" class="pure-checkbox">@Html.CheckBoxFor(m => m.AllowAnonymousPush) @Model.GetType().GetDisplayValue("AllowAnonymousPush")</label>
             <label for="IsCommitAuthorAvatarVisible" class="pure-checkbox">@Html.CheckBoxFor(m => m.IsCommitAuthorAvatarVisible) @Model.GetType().GetDisplayValue("IsCommitAuthorAvatarVisible")</label>
         </div>

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,22 @@ description: Tracks changes and bug fixes between different versions of Bonobo G
 tags: [Changelog, Changes, Bug Fixes, Features]
 ---
 
+## Version 6.0.0
+
+**TBD March 2016**
+
+### Features
+
+* A new global option allows a repository to be created by pushing at a non-existent repo name
+
+### Bugfixes
+
+### Code improvements
+
+* Addition of automated test framework for testing web application
+* Rework of repository permissions Code
+
+
 ## Version 5.1.1
 
 **12 January 2016**


### PR DESCRIPTION
Fixes #376.  Was started in PR #460 

@RedX2501 I made quite a big change to the Integration tests to provide a GitResult class rather than using the tuple (all the Item1,Item2,Item3 stuff confuses me).   I hope this isn't offensive to you - if it causes you hassle with changes you're making in parallel, I'm happy to do any tedious merge work which arises.

I feel happier in tests I write to see the asserted conditions more explicitly in the test method rather implied in the helper methods, so I've tried to allow the result to be returned to the test method instead of being consumed in the helper, but then added code in the result object to make testing stuff easy.   I would value your opinion.

I cannot get the two tests for push-to-create to work here on my machine - using the admin:admin@ style of URL with the server instance which SpecsForMVC spins-up always suffers an auth error (the client never sends the HTTP basic auth header).    I don't know why - I can use the same kind URL with the same code if I run it in Visual Studio, and the admin/admin account is OK for web-login into the SpecForMVC server instance.   However, they do work OK on Appveyer.

This PR also has a more robust DirectoryDelete routine in the integration tests, which may help with intermittent test failures.