### PR TITLE
Allow DisplayEnum to format invalid enum values without crashing

### DIFF
--- a/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
+++ b/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
@@ -165,6 +165,7 @@
     <Compile Include="IntegrationTests\Controller\AccountControllerTests.cs" />
     <Compile Include="IntegrationTests\MsysgitIntegrationTests.cs" />
     <Compile Include="IntegrationTests\MsysgitResources.cs" />
+    <Compile Include="UnitTests\CustomHtmlHelperTest.cs" />
     <Compile Include="UnitTests\PathEncoderTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestCategories.cs" />

--- a/Bonobo.Git.Server.Test/UnitTests/CustomHtmlHelperTest.cs
+++ b/Bonobo.Git.Server.Test/UnitTests/CustomHtmlHelperTest.cs
@@ -1,0 +1,47 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Web.Mvc;
+using Bonobo.Git.Server.Data;
+using Bonobo.Git.Server.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonobo.Git.Server.Test.UnitTests
+{
+    [TestClass]
+    public class CustomHtmlHelperTest
+    {
+        readonly HtmlHelper Html = new HtmlHelper(new ViewContext(), new ViewPage());
+
+        [TestMethod]
+        public void EnumsWithDisplayAttributesAreFormatted()
+        {
+            Assert.AreEqual("NameA", Html.DisplayEnum(EnumWithAttributes.A).ToString());
+            Assert.AreEqual("NameB", Html.DisplayEnum(EnumWithAttributes.B).ToString());
+        }
+
+        [TestMethod]
+        public void EnumsWithoutDisplayAttributesAreFormattedByFramework()
+        {
+            Assert.AreEqual("[[A]]", Html.DisplayEnum(EnumWithoutAttributes.A).ToString());
+            Assert.AreEqual("[[B]]", Html.DisplayEnum(EnumWithoutAttributes.B).ToString());
+        }
+
+        [TestMethod]
+        public void InvalidEnumIsFormattedByFramework()
+        {
+            Assert.AreEqual("[[7]]", Html.DisplayEnum((EnumWithoutAttributes)7).ToString());
+        }
+
+        enum EnumWithAttributes
+        {
+            [Display(Name = "NameA")]
+            A,
+            [Display(Name = "NameB")]
+            B
+        }
+        enum EnumWithoutAttributes
+        {
+            A,
+            B
+        }
+    }
+}

--- a/Bonobo.Git.Server/Helpers/CustomHtmlHelpers.cs
+++ b/Bonobo.Git.Server/Helpers/CustomHtmlHelpers.cs
@@ -30,16 +30,17 @@ namespace Bonobo.Git.Server.Helpers
         public static MvcHtmlString DisplayEnum(this HtmlHelper helper, Enum e)
         {
             string result = "[[" + e.ToString() + "]]";
-
-            var display = e.GetType()
-                       .GetMember(e.ToString()).First()
-                       .GetCustomAttributes(false)
-                       .OfType<DisplayAttribute>()
-                       .LastOrDefault();
-
-            if (display != null)
+            var memberInfo = e.GetType().GetMember(e.ToString()).FirstOrDefault();
+            if (memberInfo != null)
             {
-                result = display.GetName();
+                var display = memberInfo.GetCustomAttributes(false)
+                    .OfType<DisplayAttribute>()
+                    .LastOrDefault();
+
+                if (display != null)
+                {
+                    result = display.GetName();
+                }
             }
 
             return MvcHtmlString.Create(result);


### PR DESCRIPTION
This prevents a crash on the Repository Details page if the database contains invalid values for AllowAnonymousPush - although this problem is just down to unreleased changes pre v6.0.0, it's still good if a general purpose enum formatter performs no worse than `.ToString()`

Addresses one of the problems raised in #521 (nothing to do with routing)

