### PR TITLE
Verifies that the passed enum is a defined value 

### DIFF
--- a/Bonobo.Git.Server.Test/IntegrationTests/Controller/RepositoryControllerTests.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/Controller/RepositoryControllerTests.cs
@@ -269,5 +269,41 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             var input = app.Browser.FindElementByCssSelector("input#LinksRegex");
             Assert.IsTrue(input.GetAttribute("class").Contains("input-validation-error"));
         }
+
+        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        public void AnonymousPushModeNotAcceptInvalidValueWhenEditingRepo()
+        {
+
+            var repo_id = ITH.CreateRepositoryOnWebInterface(ITH.MakeName());
+            app.NavigateTo<RepositoryController>(c => c.Edit(repo_id));
+            var form = app.FindFormFor<RepositoryDetailModel>();
+            ITH.SetCheckbox(form.Field(f => f.AllowAnonymous).Field, true);
+            var select = new SelectElement(form.Field(f => f.AllowAnonymousPush).Field);
+
+            select.SelectByValue(((int)RepositoryPushMode.Global).ToString());
+
+            ITH.SetElementAttribute(select.Options[(int)RepositoryPushMode.Global], "value", "47");
+            form.Submit();
+
+            ITH.AssertThatValidationErrorContains(Resources.Repository_Edit_InvalidAnonymousPushMode);
+        }
+
+        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        public void AnonymousPushModeNotAcceptInvalidValueWhenCreatingRepo()
+        {
+
+            app.NavigateTo<RepositoryController>(c => c.Create());
+            var form = app.FindFormFor<RepositoryDetailModel>();
+            form.Field(f => f.Name).SetValueTo(ITH.MakeName());
+            ITH.SetCheckbox(form.Field(f => f.AllowAnonymous).Field, true);
+            var select = new SelectElement(form.Field(f => f.AllowAnonymousPush).Field);
+
+            select.SelectByValue(((int)RepositoryPushMode.Global).ToString());
+
+            ITH.SetElementAttribute(select.Options[(int)RepositoryPushMode.Global], "value", "47");
+            form.Submit();
+
+            ITH.AssertThatValidationErrorContains(Resources.Repository_Edit_InvalidAnonymousPushMode);
+        }
     }
 }

--- a/Bonobo.Git.Server.Test/IntegrationTests/IntegrationTestHelpers.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/IntegrationTestHelpers.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
 using System.Runtime.CompilerServices;
 using System.Linq.Expressions;
+using System.Web.Mvc;
 
 
 namespace Bonobo.Git.Server.Test.IntegrationTests.Helpers
@@ -292,5 +293,13 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Helpers
             SetCheckbox(field.Field, (bool)value);
             form.Submit();
         }
-     }
+
+        internal static void SetElementAttribute(IWebElement element, string attName, string attValue)
+        {
+            MvcWebApp.Driver.GetDriver()
+                .ExecuteScript("arguments[0].setAttribute(arguments[1], arguments[2]);", 
+                element, attName, attValue);
+        }
+    }
+
 }

--- a/Bonobo.Git.Server/App_GlobalResources/Resources.Designer.cs
+++ b/Bonobo.Git.Server/App_GlobalResources/Resources.Designer.cs
@@ -1593,6 +1593,15 @@ namespace Bonobo.Git.Server.App_GlobalResources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid value provided..
+        /// </summary>
+        public static string Repository_Edit_InvalidAnonymousPushMode {
+            get {
+                return ResourceManager.GetString("Repository_Edit_InvalidAnonymousPushMode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Save.
         /// </summary>
         public static string Repository_Edit_Submit {

--- a/Bonobo.Git.Server/App_GlobalResources/Resources.resx
+++ b/Bonobo.Git.Server/App_GlobalResources/Resources.resx
@@ -928,4 +928,7 @@
   <data name="Validation_Invalid_Regex" xml:space="preserve">
     <value>The provided regex has an error. {0}</value>
   </data>
+  <data name="Repository_Edit_InvalidAnonymousPushMode" xml:space="preserve">
+    <value>Invalid value provided.</value>
+  </data>
 </root>

--- a/Bonobo.Git.Server/Models/RepositoryModels.cs
+++ b/Bonobo.Git.Server/Models/RepositoryModels.cs
@@ -133,6 +133,7 @@ namespace Bonobo.Git.Server.Models
         [Display(ResourceType = typeof(Resources), Name = "Repository_Detail_Anonymous")]
         public bool AllowAnonymous { get; set; }
 
+        [EnumDataType(typeof(RepositoryPushMode), ErrorMessageResourceType=typeof(Resources), ErrorMessageResourceName="Repository_Edit_InvalidAnonymousPushMode")]
         [Display(ResourceType = typeof(Resources), Name = "Repository_Detail_AllowAnonymousPush")]
         public RepositoryPushMode AllowAnonymousPush { get; set; }
 


### PR DESCRIPTION
Complementary to #524 this will only allow valid values to be posted when creating or editing repos.