### PR TITLE
[RFC] Fix update guid

### DIFF
--- a/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
+++ b/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
@@ -171,6 +171,7 @@
     <Compile Include="TestCategories.cs" />
     <Compile Include="UnitTests\PasswordServiceTest.cs" />
     <Compile Include="UnitTests\GitAuthorizeAttributeTest.cs" />
+    <Compile Include="UnitTests\DatabaseUpdateTests.cs" />
     <Compile Include="UnitTests\UserExtensionsTests.cs" />
     <Compile Include="UnitTests\UserModelTest.cs" />
   </ItemGroup>

--- a/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
+++ b/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
@@ -166,12 +166,13 @@
     <Compile Include="IntegrationTests\MsysgitIntegrationTests.cs" />
     <Compile Include="IntegrationTests\MsysgitResources.cs" />
     <Compile Include="UnitTests\CustomHtmlHelperTest.cs" />
+    <Compile Include="UnitTests\DatabaseUpdateTestsSqlite.cs" />
+    <Compile Include="UnitTests\DatabaseUpdateTestsSqlServer.cs" />
     <Compile Include="UnitTests\PathEncoderTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestCategories.cs" />
     <Compile Include="UnitTests\PasswordServiceTest.cs" />
     <Compile Include="UnitTests\GitAuthorizeAttributeTest.cs" />
-    <Compile Include="UnitTests\DatabaseUpdateTests.cs" />
     <Compile Include="UnitTests\UserExtensionsTests.cs" />
     <Compile Include="UnitTests\UserModelTest.cs" />
   </ItemGroup>
@@ -182,7 +183,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="AllowDBResetWeb.config" />
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/Bonobo.Git.Server.Test/IntegrationTests/MsysgitIntegrationTests.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/MsysgitIntegrationTests.cs
@@ -308,15 +308,15 @@ namespace Bonobo.Git.Server.Test.Integration.ClAndWeb
         {
             ForAllGits(git =>
             {
+                // Enable the push-to-create option
+                ITH.SetGlobalSetting(x => x.AllowPushToCreate, true);
+
                 // Create a repo locally
                 Directory.CreateDirectory(RepositoryDirectory);
                 InitRepository(git);
                 Environment.CurrentDirectory = RepositoryDirectory;
                 CreateIdentity(git);
                 CreateAndAddFiles(git);
-
-                // Enable the push-to-create option
-                ITH.SetGlobalSetting(x => x.AllowPushToCreate, true);
 
                 RunGitOnRepo(git, "push origin master").ExpectSuccess();
 

--- a/Bonobo.Git.Server.Test/UnitTests/DatabaseUpdateTests.cs
+++ b/Bonobo.Git.Server.Test/UnitTests/DatabaseUpdateTests.cs
@@ -17,7 +17,6 @@ namespace Bonobo.Git.Server.Test.UnitTests
             _connection = new SqliteTestConnection();
         }
 
-        [Ignore]
         [TestMethod]
         public void RunUpdateOn_v1_2_0_25ddf80()
         {

--- a/Bonobo.Git.Server.Test/UnitTests/DatabaseUpdateTests.cs
+++ b/Bonobo.Git.Server.Test/UnitTests/DatabaseUpdateTests.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bonobo.Git.Server.Test.MembershipTests.EFTests;
+using Bonobo.Git.Server.Data.Update;
+using Bonobo.Git.Server.Data;
+
+namespace Bonobo.Git.Server.Test.UnitTests
+{
+    [TestClass]
+    public class DatabaseUpdateTests
+    {
+        protected IDatabaseTestConnection _connection;
+
+        [TestInitialize]
+        public void InitialiseTestObjects()
+        {
+            _connection = new SqliteTestConnection();
+        }
+
+        [Ignore]
+        [TestMethod]
+        public void RunUpdateOn_v1_2_0_25ddf80()
+        {
+            _connection.GetContext().Database.ExecuteSqlCommand(@"
+
+                    CREATE TABLE IF NOT EXISTS [Repository] (
+                        [Name] VarChar(255) Not Null,
+                        [Description] VarChar(255) Null,
+                        [Anonymous] Bit Not Null,
+                        Constraint [PK_Repository] Primary Key ([Name])
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [Role] (
+                        [Name] VarChar(255) Not Null,
+                        [Description] VarChar(255) Null,
+                        Constraint [PK_Role] Primary Key ([Name])
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [Team] (
+                        [Name] VarChar(255) Not Null,
+                        [Description] VarChar(255) Null,
+                        Constraint [PK_Team] Primary Key ([Name])
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [User] (
+                        [Name] VarChar(255) Not Null,
+                        [Surname] VarChar(255) Not Null,
+                        [Username] VarChar(255) Not Null,
+                        [Password] VarChar(255) Not Null,
+                        [Email] VarChar(255) Not Null,
+                        Constraint [PK_User] Primary Key ([Username])
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [TeamRepository_Permission] (
+                        [Team_Name] VarChar(255) Not Null,
+                        [Repository_Name] VarChar(255) Not Null,
+                        Constraint [UNQ_TeamRepository_Permission_1] Unique ([Team_Name], [Repository_Name]),
+                        Foreign Key ([Team_Name]) References [Team]([Name]),
+                        Foreign Key ([Repository_Name]) References [Repository]([Name])
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [UserRepository_Administrator] (
+                        [User_Username] VarChar(255) Not Null,
+                        [Repository_Name] VarChar(255) Not Null,
+                        Constraint [UNQ_UserRepository_Administrator_1] Unique ([User_Username], [Repository_Name]),
+                        Foreign Key ([User_Username]) References [User]([Username]),
+                        Foreign Key ([Repository_Name]) References [Repository]([Name])
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [UserRepository_Permission] (
+                        [User_Username] VarChar(255) Not Null,
+                        [Repository_Name] VarChar(255) Not Null,
+                        Constraint [UNQ_UserRepository_Permission_1] Unique ([User_Username], [Repository_Name]),
+                        Foreign Key ([User_Username]) References [User]([Username]),
+                        Foreign Key ([Repository_Name]) References [Repository]([Name])
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [UserRole_InRole] (
+                        [User_Username] VarChar(255) Not Null,
+                        [Role_Name] VarChar(255) Not Null,
+                        Constraint [UNQ_UserRole_InRole_1] Unique ([User_Username], [Role_Name]),
+                        Foreign Key ([User_Username]) References [User]([Username]),
+                        Foreign Key ([Role_Name]) References [Role]([Name])
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [UserTeam_Member] (
+                        [User_Username] VarChar(255) Not Null,
+                        [Team_Name] VarChar(255) Not Null,
+                        Constraint [UNQ_UserTeam_Member_1] Unique ([User_Username], [Team_Name]),
+                        Foreign Key ([User_Username]) References [User]([Username]),
+                        Foreign Key ([Team_Name]) References [Team]([Name])
+                    );
+                  
+                    ");
+            new AutomaticUpdater().RunWithContext(_connection.GetContext());
+        }
+
+        [TestMethod]
+        public void RunUpdateOn_6_0_0_0861955()
+        {
+            _connection.GetContext().Database.ExecuteSqlCommand(
+                string.Format(@"
+
+                    CREATE TABLE IF NOT EXISTS [Repository] (
+                        [Id] Char(36) PRIMARY KEY NOT NULL,
+                        [Name] VarChar(255) Not Null UNIQUE,
+                        [Description] VarChar(255) Null,
+                        [Anonymous] Bit Not Null,
+                        [AllowAnonymousPush] Integer NULL Default {0},
+                        [LinksRegex] VarChar(255) Not Null,
+                        [LinksUrl] VarChar(255) Not Null,
+                        [LinksUseGlobal] Bit default 1 Not Null,
+                        UNIQUE ([Name] COLLATE NOCASE)
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [Role] (
+                        [Id] Char(36) PRIMARY KEY,
+                        [Name] VarChar(255) Not Null UNIQUE,
+                        [Description] VarChar(255) Null
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [Team] (
+                        [Id] Char(36) PRIMARY KEY,
+                        [Name] VarChar(255) Not Null UNIQUE,
+                        [Description] VarChar(255) Null
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [User] (
+                        [Id] Char(36) PRIMARY KEY,
+                        [Name] VarChar(255) Not Null,
+                        [Surname] VarChar(255) Not Null,
+                        [Username] VarChar(255) Not Null UNIQUE,
+                        [Password] VarChar(255) Not Null,
+                        [PasswordSalt] VarChar(255) Not Null,
+                        [Email] VarChar(255) Not Null
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [TeamRepository_Permission] (
+                        [Team_Id] Char(36) Not Null,
+                        [Repository_Id] Char(36) Not Null,
+                        Constraint [UNQ_TeamRepository_Permission_1] Unique ([Team_Id], [Repository_Id]),
+                        Foreign Key ([Team_Id]) References [Team]([Id]),
+                        Foreign Key ([Repository_Id]) References [Repository]([Id])
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [UserRepository_Administrator] (
+                        [User_Id] Char(36) Not Null,
+                        [Repository_Id] Char(36) Not Null,
+                        Constraint [UNQ_UserRepository_Administrator_1] Unique ([User_Id], [Repository_Id]),
+                        Foreign Key ([User_Id]) References [User]([Id]),
+                        Foreign Key ([Repository_Id]) References [Repository]([Id])
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [UserRepository_Permission] (
+                        [User_Id] Char(36) Not Null,
+                        [Repository_Id] Char(36) Not Null,
+                        Constraint [UNQ_UserRepository_Permission_1] Unique ([User_Id], [Repository_Id]),
+                        Foreign Key ([User_Id]) References [User]([Id]),
+                        Foreign Key ([Repository_Id]) References [Repository]([Id])
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [UserRole_InRole] (
+                        [User_Id] Char(36) Not Null,
+                        [Role_Id] Char(36) Not Null,
+                        Constraint [UNQ_UserRole_InRole_1] Unique ([User_Id], [Role_Id]),
+                        Foreign Key ([User_Id]) References [User]([Id]),
+                        Foreign Key ([Role_Id]) References [Role]([Id])
+                    );
+
+                    CREATE TABLE IF NOT EXISTS [UserTeam_Member] (
+                        [User_Id] Char(36) Not Null,
+                        [Team_Id] Char(36) Not Null,
+                        Constraint [UNQ_UserTeam_Member_1] Unique ([User_Id], [Team_Id]),
+                        Foreign Key ([User_Id]) References [User]([Id]),
+                        Foreign Key ([Team_Id]) References [Team]([Id])
+                    );
+
+                    ", (int)RepositoryPushMode.Global)
+            );
+        }
+    }
+}

--- a/Bonobo.Git.Server.Test/UnitTests/DatabaseUpdateTestsSqlServer.cs
+++ b/Bonobo.Git.Server.Test/UnitTests/DatabaseUpdateTestsSqlServer.cs
@@ -1,0 +1,331 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bonobo.Git.Server.Test.MembershipTests.EFTests;
+using Bonobo.Git.Server.Data.Update;
+using Bonobo.Git.Server.Data;
+
+namespace Bonobo.Git.Server.Test.UnitTests
+{
+    [TestClass]
+    public class DatabaseUpdateTestsSqlServer
+    {
+        protected IDatabaseTestConnection _connection;
+
+        [TestInitialize]
+        public void InitialiseTestObjects()
+        {
+            _connection = new SqlServerTestConnection();
+        }
+
+        // There is not test for version 1.2.0 because SqlServer was first introduced in 2.1
+        [TestMethod]
+        public void RunUpdateOn_2_1_96fa2a()
+        {
+            _connection.GetContext().Database.ExecuteSqlCommand(@"
+                IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Repository'))
+                    BEGIN
+                        CREATE TABLE [Repository] (
+                            [Name] VarChar(255) Not Null,
+                            [Description] VarChar(255) Null,
+                            [Anonymous] Bit Not Null,
+                            Constraint [PK_Repository] Primary Key ([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Role'))
+                    BEGIN
+                        CREATE TABLE [Role] (
+                            [Name] VarChar(255) Not Null,
+                            [Description] VarChar(255) Null,
+                            Constraint [PK_Role] Primary Key ([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Team'))
+                    BEGIN
+                        CREATE TABLE [Team] (
+                            [Name] VarChar(255) Not Null,
+                            [Description] VarChar(255) Null,
+                            Constraint [PK_Team] Primary Key ([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'User'))
+                    BEGIN
+                        CREATE TABLE [User] (
+                            [Name] VarChar(255) Not Null,
+                            [Surname] VarChar(255) Not Null,
+                            [Username] VarChar(255) Not Null,
+                            [Password] VarChar(255) Not Null,
+                            [Email] VarChar(255) Not Null,
+                            Constraint [PK_User] Primary Key ([Username])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'TeamRepository_Permission'))
+                    BEGIN
+                        CREATE TABLE [TeamRepository_Permission] (
+                            [Team_Name] VarChar(255) Not Null,
+                            [Repository_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_TeamRepository_Permission_1] Unique ([Team_Name], [Repository_Name]),
+                            Foreign Key ([Team_Name]) References [Team]([Name]),
+                            Foreign Key ([Repository_Name]) References [Repository]([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserRepository_Administrator'))
+                    BEGIN
+                        CREATE TABLE [UserRepository_Administrator] (
+                            [User_Username] VarChar(255) Not Null,
+                            [Repository_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_UserRepository_Administrator_1] Unique ([User_Username], [Repository_Name]),
+                            Foreign Key ([User_Username]) References [User]([Username]),
+                            Foreign Key ([Repository_Name]) References [Repository]([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserRepository_Permission'))
+                    BEGIN
+                        CREATE TABLE [UserRepository_Permission] (
+                            [User_Username] VarChar(255) Not Null,
+                            [Repository_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_UserRepository_Permission_1] Unique ([User_Username], [Repository_Name]),
+                            Foreign Key ([User_Username]) References [User]([Username]),
+                            Foreign Key ([Repository_Name]) References [Repository]([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserRole_InRole'))
+                    BEGIN
+                        CREATE TABLE [UserRole_InRole] (
+                            [User_Username] VarChar(255) Not Null,
+                            [Role_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_UserRole_InRole_1] Unique ([User_Username], [Role_Name]),
+                            Foreign Key ([User_Username]) References [User]([Username]),
+                            Foreign Key ([Role_Name]) References [Role]([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserTeam_Member'))
+                    BEGIN
+                        CREATE TABLE [UserTeam_Member] (
+                            [User_Username] VarChar(255) Not Null,
+                            [Team_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_UserTeam_Member_1] Unique ([User_Username], [Team_Name]),
+                            Foreign Key ([User_Username]) References [User]([Username]),
+                            Foreign Key ([Team_Name]) References [Team]([Name])
+                        );
+                    END
+                ");
+        }
+
+        [TestMethod]
+        public void RunUpdateOn_3_3_0_c6e0c6()
+        {
+            _connection.GetContext().Database.ExecuteSqlCommand(@"
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Repository'))
+                    BEGIN
+                        CREATE TABLE [dbo].[Repository] (
+                            [Name] VarChar(255) Not Null,
+                            [Description] VarChar(255) Null,
+                            [Anonymous] Bit Not Null,
+                            Constraint [PK_Repository] Primary Key ([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Role'))
+                    BEGIN
+                        CREATE TABLE [dbo].[Role] (
+                            [Name] VarChar(255) Not Null,
+                            [Description] VarChar(255) Null,
+                            Constraint [PK_Role] Primary Key ([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Team'))
+                    BEGIN
+                        CREATE TABLE [dbo].[Team] (
+                            [Name] VarChar(255) Not Null,
+                            [Description] VarChar(255) Null,
+                            Constraint [PK_Team] Primary Key ([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'User'))
+                    BEGIN
+                        CREATE TABLE [dbo].[User] (
+                            [Name] VarChar(255) Not Null,
+                            [Surname] VarChar(255) Not Null,
+                            [Username] VarChar(255) Not Null,
+                            [Password] VarChar(255) Not Null,
+                            [Email] VarChar(255) Not Null,
+                            Constraint [PK_User] Primary Key ([Username])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'TeamRepository_Permission'))
+                    BEGIN
+                        CREATE TABLE [dbo].[TeamRepository_Permission] (
+                            [Team_Name] VarChar(255) Not Null,
+                            [Repository_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_TeamRepository_Permission_1] Unique ([Team_Name], [Repository_Name]),
+                            Foreign Key ([Team_Name]) References [Team]([Name]),
+                            Foreign Key ([Repository_Name]) References [Repository]([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserRepository_Administrator'))
+                    BEGIN
+                        CREATE TABLE [dbo].[UserRepository_Administrator] (
+                            [User_Username] VarChar(255) Not Null,
+                            [Repository_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_UserRepository_Administrator_1] Unique ([User_Username], [Repository_Name]),
+                            Foreign Key ([User_Username]) References [User]([Username]),
+                            Foreign Key ([Repository_Name]) References [Repository]([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserRepository_Permission'))
+                    BEGIN
+                        CREATE TABLE [dbo].[UserRepository_Permission] (
+                            [User_Username] VarChar(255) Not Null,
+                            [Repository_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_UserRepository_Permission_1] Unique ([User_Username], [Repository_Name]),
+                            Foreign Key ([User_Username]) References [User]([Username]),
+                            Foreign Key ([Repository_Name]) References [Repository]([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserRole_InRole'))
+                    BEGIN
+                        CREATE TABLE [dbo].[UserRole_InRole] (
+                            [User_Username] VarChar(255) Not Null,
+                            [Role_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_UserRole_InRole_1] Unique ([User_Username], [Role_Name]),
+                            Foreign Key ([User_Username]) References [User]([Username]),
+                            Foreign Key ([Role_Name]) References [Role]([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserTeam_Member'))
+                    BEGIN
+                        CREATE TABLE [dbo].[UserTeam_Member] (
+                            [User_Username] VarChar(255) Not Null,
+                            [Team_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_UserTeam_Member_1] Unique ([User_Username], [Team_Name]),
+                            Foreign Key ([User_Username]) References [User]([Username]),
+                            Foreign Key ([Team_Name]) References [Team]([Name])
+                        );
+                    END
+            ");
+        }
+
+        [TestMethod]
+        public void RunUpdateOn_6_0_0_0861955()
+        {
+            _connection.GetContext().Database.ExecuteSqlCommand(
+                string.Format(@"
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Repository'))
+                    BEGIN
+                        CREATE TABLE [dbo].[Repository] (
+                            [Name] VarChar(255) Not Null,
+                            [Description] VarChar(255) Null,
+                            [Anonymous] Bit Not Null,
+                            [AllowAnonymousPush] Integer Default {0} Not Null,
+                            [LinksRegex] VarChar(255) Not Null,
+                            [LinksUrl] VarChar(255) Not Null,
+                            [LinksUseGlobal] Bit Default 1 Not Null,
+                            Constraint [PK_Repository] Primary Key ([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Role'))
+                    BEGIN
+                        CREATE TABLE [dbo].[Role] (
+                            [Name] VarChar(255) Not Null,
+                            [Description] VarChar(255) Null,
+                            Constraint [PK_Role] Primary Key ([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Team'))
+                    BEGIN
+                        CREATE TABLE [dbo].[Team] (
+                            [Name] VarChar(255) Not Null,
+                            [Description] VarChar(255) Null,
+                            Constraint [PK_Team] Primary Key ([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'User'))
+                    BEGIN
+                        CREATE TABLE [dbo].[User] (
+                            [Name] VarChar(255) Not Null,
+                            [Surname] VarChar(255) Not Null,
+                            [Username] VarChar(255) Not Null,
+                            [Password] VarChar(255) Not Null,
+                            [Email] VarChar(255) Not Null,
+                            Constraint [PK_User] Primary Key ([Username])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'TeamRepository_Permission'))
+                    BEGIN
+                        CREATE TABLE [dbo].[TeamRepository_Permission] (
+                            [Team_Name] VarChar(255) Not Null,
+                            [Repository_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_TeamRepository_Permission_1] Unique ([Team_Name], [Repository_Name]),
+                            Foreign Key ([Team_Name]) References [Team]([Name]),
+                            Foreign Key ([Repository_Name]) References [Repository]([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserRepository_Administrator'))
+                    BEGIN
+                        CREATE TABLE [dbo].[UserRepository_Administrator] (
+                            [User_Username] VarChar(255) Not Null,
+                            [Repository_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_UserRepository_Administrator_1] Unique ([User_Username], [Repository_Name]),
+                            Foreign Key ([User_Username]) References [User]([Username]),
+                            Foreign Key ([Repository_Name]) References [Repository]([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserRepository_Permission'))
+                    BEGIN
+                        CREATE TABLE [dbo].[UserRepository_Permission] (
+                            [User_Username] VarChar(255) Not Null,
+                            [Repository_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_UserRepository_Permission_1] Unique ([User_Username], [Repository_Name]),
+                            Foreign Key ([User_Username]) References [User]([Username]),
+                            Foreign Key ([Repository_Name]) References [Repository]([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserRole_InRole'))
+                    BEGIN
+                        CREATE TABLE [dbo].[UserRole_InRole] (
+                            [User_Username] VarChar(255) Not Null,
+                            [Role_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_UserRole_InRole_1] Unique ([User_Username], [Role_Name]),
+                            Foreign Key ([User_Username]) References [User]([Username]),
+                            Foreign Key ([Role_Name]) References [Role]([Name])
+                        );
+                    END
+
+                    IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'UserTeam_Member'))
+                    BEGIN
+                        CREATE TABLE [dbo].[UserTeam_Member] (
+                            [User_Username] VarChar(255) Not Null,
+                            [Team_Name] VarChar(255) Not Null,
+                            Constraint [UNQ_UserTeam_Member_1] Unique ([User_Username], [Team_Name]),
+                            Foreign Key ([User_Username]) References [User]([Username]),
+                            Foreign Key ([Team_Name]) References [Team]([Name])
+                        );
+                    END
+
+                    ", (int)RepositoryPushMode.Global)
+            );
+        }
+    }
+}

--- a/Bonobo.Git.Server.Test/UnitTests/DatabaseUpdateTestsSqlite.cs
+++ b/Bonobo.Git.Server.Test/UnitTests/DatabaseUpdateTestsSqlite.cs
@@ -7,7 +7,7 @@ using Bonobo.Git.Server.Data;
 namespace Bonobo.Git.Server.Test.UnitTests
 {
     [TestClass]
-    public class DatabaseUpdateTests
+    public class DatabaseUpdateTestsSqlite
     {
         protected IDatabaseTestConnection _connection;
 

--- a/Bonobo.Git.Server/Data/Update/SqlServer/InitialCreateScript.cs
+++ b/Bonobo.Git.Server/Data/Update/SqlServer/InitialCreateScript.cs
@@ -8,6 +8,7 @@ namespace Bonobo.Git.Server.Data.Update.SqlServer
         {
             get
             {
+                // If you modify this scheme make sure to introduce an unit test for the new scheme.
                 return string.Format(@"
                     IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND  TABLE_NAME = 'Repository'))
                     BEGIN

--- a/Bonobo.Git.Server/Data/Update/SqlServer/InsertDefaultData.cs
+++ b/Bonobo.Git.Server/Data/Update/SqlServer/InsertDefaultData.cs
@@ -6,13 +6,17 @@ namespace Bonobo.Git.Server.Data.Update.SqlServer
     {
         public string Command
         {
-            get { return @"
+            get
+            {
+                Guid roleId = new Guid("a3139d2b-5a59-427f-bb2d-af251dce00e4");
+                Guid UserId = new Guid("3eb9995e-99e3-425a-b978-1409bdd61fb6");
+                return @"
 
-                    INSERT INTO [Role] ([Name], [Description]) VALUES ('Administrator','System administrator');
-                    INSERT INTO [User] ([Name], [Surname], [Username], [Password], [Email]) VALUES ('admin', '', 'admin', '0CC52C6751CC92916C138D8D714F003486BF8516933815DFC11D6C3E36894BFA044F97651E1F3EEBA26CDA928FB32DE0869F6ACFB787D5A33DACBA76D34473A3', '');
-                    INSERT INTO [UserRole_InRole] ([User_Username], [Role_Name]) VALUES ('admin', 'Administrator');
-
-                    "; }
+                    INSERT INTO [Role] ([Id], [Name], [Description]) VALUES ('" + roleId +@"','Administrator','System administrator');
+                    INSERT INTO [User] ([Id], [Name], [Surname], [Username], [Password], [PasswordSalt], [Email]) VALUES ('" +UserId +@"','admin', '', 'admin', '0CC52C6751CC92916C138D8D714F003486BF8516933815DFC11D6C3E36894BFA044F97651E1F3EEBA26CDA928FB32DE0869F6ACFB787D5A33DACBA76D34473A3', 'admin', '');
+                    INSERT INTO [UserRole_InRole] ([User_Id], [Role_Id]) VALUES ('" + UserId + "','" + roleId + @"');
+                    ";
+            }
         }
 
         public string Precondition

--- a/Bonobo.Git.Server/Data/Update/Sqlite/AddGuidColumn.cs
+++ b/Bonobo.Git.Server/Data/Update/Sqlite/AddGuidColumn.cs
@@ -103,7 +103,7 @@ namespace Bonobo.Git.Server.Data.Update.Sqlite
                                            UNIQUE,
                     Password VARCHAR (255) NOT NULL,
                     PasswordSalt VARCHAR (255) NOT NULL,
-                    Email    VARCHAR (255) NOT NULL,
+                    Email    VARCHAR (255) NOT NULL
                 );
 
                 CREATE TABLE Team (

--- a/Bonobo.Git.Server/Data/Update/Sqlite/InitialCreateScript.cs
+++ b/Bonobo.Git.Server/Data/Update/Sqlite/InitialCreateScript.cs
@@ -9,6 +9,7 @@ namespace Bonobo.Git.Server.Data.Update.Sqlite
         {
             get 
             {
+                // If you modify this scheme make sure to introduce an unit test for the new scheme.
                 return string.Format(@"
 
                     CREATE TABLE IF NOT EXISTS [Repository] (

--- a/Bonobo.Git.Server/Data/Update/UpdateScriptRepository.cs
+++ b/Bonobo.Git.Server/Data/Update/UpdateScriptRepository.cs
@@ -16,27 +16,27 @@ namespace Bonobo.Git.Server.Data.Update
                     return new List<IUpdateScript>
                     {
                         new Sqlite.InitialCreateScript(),
-                        new Sqlite.InsertDefaultData(),
                         new UsernamesToLower(),
                         new Sqlite.AddAuditPushUser(),
                         new Sqlite.AddGroup(),
                         new Sqlite.AddRepositoryLogo(),
                         new Sqlite.AddGuidColumn(),
                         new Sqlite.AddRepoPushColumn(),
-                        new Sqlite.AddRepoLinksColumn()
+                        new Sqlite.AddRepoLinksColumn(),
+                        new Sqlite.InsertDefaultData()
                     };
                 case "SqlConnection":
                     return new List<IUpdateScript>
                     {
                         new SqlServer.InitialCreateScript(),
-                        new SqlServer.InsertDefaultData(),
                         new UsernamesToLower(),
                         new SqlServer.AddAuditPushUser(),
                         new SqlServer.AddGroup(),
                         new SqlServer.AddRepositoryLogo(),
                         new SqlServer.AddGuidColumn(),
                         new SqlServer.AddRepoPushColumn(),
-                        new SqlServer.AddRepoLinksColumn()
+                        new SqlServer.AddRepoLinksColumn(),
+                        new SqlServer.InsertDefaultData()
                     };
                 default:
                     throw new NotImplementedException(string.Format("The provider '{0}' is not supported yet", sqlProvider));


### PR DESCRIPTION
I tried creating tests for the update paths but it seems that all InitialCreateScript versions were to same up until this release.

Yet the upgrade fails when going from 1.2.0 to the latest version. I must be missing something.

I used following script to get all the release InitialCreateScript versions that were released:

```
#!/usr/bin/env bash

set -e
set -u

while IFS= read -r info; do
	sha=${info%% *}
	tag=${info##*/}
	echo "sha ${sha:0:6} tag $tag"
	while IFS= read -r script; do
		if ! [[ $script =~ "SqlServer" ]]; then
			echo "i $script"
			git checkout -f $sha
			filename=$(basename $script)
			ext=${filename##*.}
			mv $script "./${filename%.*}_${tag}_${sha:0:6}.$ext"
		fi
	done < <(git ls-tree -r --name-only $sha | grep -i InitialCreateScript.cs)
done < <(git show-ref --tags)
```