### PR TITLE
[RTM] Removed #if from Application_Error handler. Fix #532

### DIFF
--- a/Bonobo.Git.Server/Global.asax.cs
+++ b/Bonobo.Git.Server/Global.asax.cs
@@ -237,7 +237,6 @@ namespace Bonobo.Git.Server
         }
 
 
-#if !DEBUG
         protected void Application_Error(object sender, EventArgs e)
         {
             Exception exception = Server.GetLastError();
@@ -279,7 +278,6 @@ namespace Bonobo.Git.Server
                 errorController.Execute(new RequestContext(new HttpContextWrapper(Context), routeData));
             }
         }
-#endif
 
         private static string GetRootPath(string path)
         {


### PR DESCRIPTION
I don't see any problems with havin it enabled in debug mode. In production it was enabled anyway.