### PR TITLE
AD Controller event log spamming

### DIFF
--- a/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
+++ b/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
@@ -118,7 +118,7 @@ namespace Bonobo.Git.Server
                     var adUser = UserPrincipal.FindByIdentity(pc, username);
                     if (adUser != null)
                     {
-                        if (pc.ValidateCredentials(username, password))
+                        if (pc.ValidateCredentials(username, password, ContextOptions.Negotiate))
                         {
                             httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(AuthenticationProvider.GetClaimsForUser(username.Replace("\\", "!"))));
                             return true;

--- a/Bonobo.Git.Server/Security/ADMembershipService.cs
+++ b/Bonobo.Git.Server/Security/ADMembershipService.cs
@@ -41,7 +41,7 @@ namespace Bonobo.Git.Server.Security
 
                 using (PrincipalContext principalContext = new PrincipalContext(ContextType.Domain, domain))
                 {
-                    if (principalContext.ValidateCredentials(username, password))
+                    if (principalContext.ValidateCredentials(username, password,ContextOptions.Negotiate))
                     {
                         using (UserPrincipal user = UserPrincipal.FindByIdentity(principalContext, username))
                         {

--- a/Bonobo.Git.Server/Security/ADMembershipService.cs
+++ b/Bonobo.Git.Server/Security/ADMembershipService.cs
@@ -41,7 +41,7 @@ namespace Bonobo.Git.Server.Security
 
                 using (PrincipalContext principalContext = new PrincipalContext(ContextType.Domain, domain))
                 {
-                    if (principalContext.ValidateCredentials(username, password,ContextOptions.Negotiate))
+                    if (principalContext.ValidateCredentials(username, password, ContextOptions.Negotiate))
                     {
                         using (UserPrincipal user = UserPrincipal.FindByIdentity(principalContext, username))
                         {


### PR DESCRIPTION
Fixed issue where the AD validation would cause a lot of events in the AD Controller event log everytime a login happend and SSL is not used.