### PR TITLE
[WIP] Test credentials

### DIFF
--- a/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
+++ b/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
@@ -55,6 +55,10 @@
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
@@ -134,6 +138,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="IntegrationTests\LoadedConfig.cs" />
     <Compile Include="IntegrationTests\IntegrationTestBase.cs" />
     <Compile Include="IntegrationTests\Controller\TeamControllerTests.cs" />
     <Compile Include="IntegrationTests\SharedLayoutTests.cs" />

--- a/Bonobo.Git.Server.Test/IntegrationTests/AssemblyStartup.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/AssemblyStartup.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.IO;
-using SpecsFor;
+using System.Collections.Generic;
 using SpecsFor.Mvc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-using Bonobo.Git.Server;
-using Bonobo.Git.Server.Controllers;
-using Bonobo.Git.Server.Models;
 using Bonobo.Git.Server.App_GlobalResources;
+using Newtonsoft.Json;
 
-namespace Bonobo.Git.Server.IntegrationTests
+namespace Bonobo.Git.Server.Test.IntegrationTests
 {
     [TestClass]
     public class AssemblyStartup
@@ -17,12 +14,33 @@ namespace Bonobo.Git.Server.IntegrationTests
         private static SpecsForIntegrationHost _host;
         public static string WebApplicationDirectory;
 
+        private readonly static string ConfigFile = Path.GetFullPath(@"..\..\config.json");
+
+        public static LoadedConfig LoadedConfig; 
+
+        public static LoadedConfig LoadConfiguration()
+        {
+            var creds = new Dictionary<string, Dictionary<string, string>>
+            {
+                {"admin", new Dictionary<string, string>{{ "username", "admin" }, {"password", "admin"} } },
+                {"user", new Dictionary<string, string>{{"username", "user"}, { "password", "uiae"} } }
+            };
+            if (File.Exists(ConfigFile))
+            {
+                creds = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(File.ReadAllText(ConfigFile));
+            }
+            return new LoadedConfig(creds);
+        }
+
+
 #if !NCRUNCH
         [AssemblyInitialize()]
         static public void AssemblyInit(TestContext tc)
         {
             // so we can use the resources in our test even if your language is not en-US
             Resources.Culture = new System.Globalization.CultureInfo("en-US");
+
+            LoadedConfig = LoadConfiguration();
 
             var config = new SpecsForMvcConfig();
             //SpecsFor.Mvc can spin up an instance of IIS Express to host your app 

--- a/Bonobo.Git.Server.Test/IntegrationTests/Controller/AccountControllerTests.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/Controller/AccountControllerTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
 {
     using ITH = IntegrationTestHelpers;
+    using TC = TestCategories;
 
     public class AccountControllerSpecs
     {
@@ -17,7 +18,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
         public class AccountControllerTests : IntegrationTestBase
         {
 
-            [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+            [TestMethod, TestCategory(TC.IntegrationTest), TestCategory(TC.StorageInternal)]
             public void UserDetailRequiresLogin()
             {
                 app.NavigateTo<HomeController>(c => c.LogOff());
@@ -28,7 +29,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
                 app.UrlShouldMapTo<HomeController>(c => c.LogOn("/Account/Detail/7479fc09-2c0b-4e93-a2cf-5e4bbf6bab4f"));
             }
 
-            [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+            [TestMethod, TestCategory(TC.IntegrationTest), TestCategory(TC.AuthForms)]
             public void LoginWithoutCredentialFailsWithInvalidMessages()
             {
                 app.NavigateTo<HomeController>(c => c.LogOn("/"));
@@ -43,7 +44,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
                     .Field(f => f.Password).ShouldBeInvalid();
             }
 
-            [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+            [TestMethod, TestCategory(TC.IntegrationTest), TestCategory(TC.StorageInternal)]
             public void UsernameEnsureDuplicationDetectionAsYouTypeWorksOnCreation()
             {
                 var id1 = ITH.CreateUsers().Single();
@@ -59,7 +60,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
                 Assert.IsTrue(input.GetAttribute("class").Contains("input-validation-error"));
             }
 
-            [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+            [TestMethod, TestCategory(TC.IntegrationTest), TestCategory(TC.StorageInternal)]
             public void UsernameEnsureDuplicationDetectionAsYouTypeWorksOnEdit()
             {
                 var ids = ITH.CreateUsers(2).ToList();
@@ -77,7 +78,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
                 Assert.IsTrue(input.GetAttribute("class").Contains("input-validation-error"));
             }
 
-            [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+            [TestMethod, TestCategory(TC.IntegrationTest), TestCategory(TC.StorageInternal)]
             public void UsernameEnsureDuplicationDetectionStillAllowsEditOtherProperties()
             {
                 var ids = ITH.CreateUsers().ToList();

--- a/Bonobo.Git.Server.Test/IntegrationTests/Controller/RepositoryControllerTests.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/Controller/RepositoryControllerTests.cs
@@ -12,11 +12,12 @@ using System.Linq;
 namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
 {
     using ITH = IntegrationTestHelpers;
+    using TC = TestCategories;
 
     [TestClass]
     public class RepositoryControllerTests : IntegrationTestBase
     {
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest), TestCategory(TC.StorageInternal)]
         public void EnsureCheckboxesStayCheckOnCreateError()
         {
             ITH.CreateUsers(1);
@@ -37,7 +38,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             }
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void CreateDuplicateRepoNameDifferentCaseNotAllowed()
         {
             var reponame = ITH.MakeName();
@@ -54,7 +55,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             Assert.AreEqual(Resources.Validation_Duplicate_Name, field.HasValidationMessage().Text);
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void CreateDuplicateRepoNameNotAllowed()
         {
             var reponame = ITH.MakeName();
@@ -71,7 +72,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             Assert.AreEqual(Resources.Validation_Duplicate_Name, field.HasValidationMessage().Text);
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void RenameRepoToExistingRepoNameNotAllowed()
         {
             var reponame = ITH.MakeName();
@@ -91,7 +92,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             Assert.AreEqual(Resources.Validation_Duplicate_Name, validationmsg.Text);
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void RenameRepoToExistingRepoNameNotAllowedDifferentCase()
         {
             var reponame = ITH.MakeName();
@@ -110,7 +111,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             Assert.AreEqual(Resources.Validation_Duplicate_Name, field.HasValidationMessage().Text);
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void RepositoryCanBeSavedBySysAdminWithoutHavingAnyRepoAdmins()
         {
             var repoId = ITH.CreateRepositoryOnWebInterface(ITH.MakeName());
@@ -126,7 +127,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             ITH.AssertThatNoValidationErrorOccurred();
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void RepoAdminCannotRemoveThemselves()
         {
             var user = ITH.CreateUsers().Single();
@@ -159,7 +160,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             ITH.AssertThatValidationErrorContains(Resources.Repository_Edit_CantRemoveYourself);
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void RepoAnonPushDefaultSettingsForRepoCreationShouldBeGlobal()
         {
             app.NavigateTo<RepositoryController>(c => c.Create());
@@ -169,7 +170,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             Assert.AreEqual(RepositoryPushMode.Global.ToString("D"), select.SelectedOption.GetAttribute("value"));
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void SettingsAcceptEmptyStringForRegex()
         {
             ITH.SetGlobalSetting(g => g.LinksRegex, "some_value");
@@ -184,7 +185,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             Assert.AreEqual(false, field.Field.GetAttribute("class").Contains("valid"));
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void DoesNotAcceptBrokenRegexForLinks()
         {
             app.NavigateTo<SettingsController>(c => c.Index());
@@ -196,7 +197,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
                 .Field(f => f.LinksRegex).ShouldBeInvalid();
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void RepoNameEnsureDuplicationDetectionAsYouTypeWorksOnCreation()
         {
             var reponame = ITH.MakeName();
@@ -214,7 +215,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             Assert.IsTrue(input.GetAttribute("class").Contains("input-validation-error"));
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void RepoNameEnsureDuplicationDetectionAsYouTypeWorksOnEdit()
         {
             var reponame = ITH.MakeName();
@@ -234,7 +235,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             Assert.IsTrue(input.GetAttribute("class").Contains("input-validation-error"));
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void RepoNameEnsureDuplicationDetectionStillAllowsEditOtherProperties()
         {
             var reponame = ITH.MakeName();
@@ -250,7 +251,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
                 .Field(f => f.Description).ValueShouldEqual(reponame + "_other");
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void InvalidLinkifyRegexAsYouTypeInRepository()
         {
             var reponame = ITH.MakeName();
@@ -270,7 +271,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             Assert.IsTrue(input.GetAttribute("class").Contains("input-validation-error"));
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void AnonymousPushModeNotAcceptInvalidValueWhenEditingRepo()
         {
 
@@ -288,7 +289,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             ITH.AssertThatValidationErrorContains(Resources.Repository_Edit_InvalidAnonymousPushMode);
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest)]
         public void AnonymousPushModeNotAcceptInvalidValueWhenCreatingRepo()
         {
 

--- a/Bonobo.Git.Server.Test/IntegrationTests/Controller/SettingsControllerTests.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/Controller/SettingsControllerTests.cs
@@ -14,7 +14,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
     [TestClass]
     public class SettingsControllerTests : IntegrationTestBase
     {
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TestCategories.IntegrationTest)]
         public void EnsureSelectedLanguageIsSaved()
         {
             app.NavigateTo<SettingsController>(c => c.Index());
@@ -34,7 +34,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
             form.Submit();
         }
 
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TestCategories.IntegrationTest)]
         public void InvalidLinkifyRegexAsYouTypeInSettings()
         {
             var brokenRegex = @"\";

--- a/Bonobo.Git.Server.Test/IntegrationTests/Controller/TeamControllerTests.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/Controller/TeamControllerTests.cs
@@ -16,7 +16,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
         public class TeamControllerTests : IntegrationTestBase
         {
 
-            [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+            [TestMethod, TestCategory(TestCategories.IntegrationTest)]
             public void TeamNameEnsureDuplicationDetectionAsYouTypeWorksOnCreation()
             {
                 var id1 = ITH.CreateTeams().Single();
@@ -30,7 +30,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
                 Assert.IsTrue(input.GetAttribute("class").Contains("input-validation-error"));
             }
 
-            [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+            [TestMethod, TestCategory(TestCategories.IntegrationTest)]
             public void TeamNameEnsureDuplicationDetectionAsYouTypeWorksOnEdit()
             {
                 var teams = ITH.CreateTeams(2).ToList();
@@ -48,7 +48,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Controller
                 Assert.IsTrue(input.GetAttribute("class").Contains("input-validation-error"));
             }
 
-            [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+            [TestMethod, TestCategory(TestCategories.IntegrationTest)]
             public void TeamNameEnsureDuplicationDetectionStillAllowsEditOtherProperties()
             {
                 var ids = ITH.CreateTeams().ToList();

--- a/Bonobo.Git.Server.Test/IntegrationTests/IntegrationTestBase.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/IntegrationTestBase.cs
@@ -10,6 +10,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests
     {
         protected static MvcWebApp app;
         protected static IntegrationTestHelpers ITH;
+        protected static LoadedConfig lc;
 
         [ClassCleanup]
         public static void Cleanup()
@@ -24,7 +25,8 @@ namespace Bonobo.Git.Server.Test.IntegrationTests
             if (app == null)
             {
                 app = new MvcWebApp();
-                ITH = new IntegrationTestHelpers(app);
+                lc = AssemblyStartup.LoadedConfig;
+                ITH = new IntegrationTestHelpers(app, lc);
             }
             Console.WriteLine("TestInit");
             ITH.LoginAndResetDatabase();

--- a/Bonobo.Git.Server.Test/IntegrationTests/IntegrationTestHelpers.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/IntegrationTestHelpers.cs
@@ -1,22 +1,15 @@
-﻿using System;
+﻿using Bonobo.Git.Server.Controllers;
+using Bonobo.Git.Server.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
+using SpecsFor.Mvc;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Net;
-using System.Reflection;
-using System.Threading;
-using SpecsFor.Mvc;
-
-using Bonobo.Git.Server.Models;
-using Bonobo.Git.Server.Controllers;
-using Bonobo.Git.Server.IntegrationTests;
-using Bonobo.Git.Server.Test.MembershipTests.ADTests;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium;
-using System.Runtime.CompilerServices;
 using System.Linq.Expressions;
-using System.Web.Mvc;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 
 namespace Bonobo.Git.Server.Test.IntegrationTests.Helpers
@@ -24,28 +17,32 @@ namespace Bonobo.Git.Server.Test.IntegrationTests.Helpers
     public class IntegrationTestHelpers
     {
         private readonly MvcWebApp _app;
+        private readonly LoadedConfig _lc;
 
-        public IntegrationTestHelpers(MvcWebApp app)
+        public IntegrationTestHelpers(MvcWebApp app, LoadedConfig cc)
         {
             _app = app;
+            _lc = cc;
         }
 
         public void LoginAsAdmin()
         {
+            var cred = _lc.getCredentials("admin");
             _app.NavigateTo<HomeController>(c => c.LogOn("/Account"));
             _app.FindFormFor<LogOnModel>()
-                .Field(f => f.Username).SetValueTo("admin")
-                .Field(f => f.Password).SetValueTo("admin")
+                .Field(f => f.Username).SetValueTo(cred.Item1)
+                .Field(f => f.Password).SetValueTo(cred.Item2)
                 .Submit();
             _app.UrlMapsTo<AccountController>(c => c.Index());
         }
 
         public void LoginAndResetDatabase()
         {
+            var cred = _lc.getCredentials("admin");
             _app.NavigateTo<HomeController>(c => c.LogOnWithResetOption("/Account"));
             _app.FindFormFor<LogOnModel>()
-                .Field(f => f.Username).SetValueTo("admin")
-                .Field(f => f.Password).SetValueTo("admin")
+                .Field(f => f.Username).SetValueTo(cred.Item1)
+                .Field(f => f.Password).SetValueTo(cred.Item2)
                 .Field(f => f.DatabaseResetCode).SetValueTo("1")
                 .Submit();
             _app.UrlMapsTo<AccountController>(c => c.Index());

--- a/Bonobo.Git.Server.Test/IntegrationTests/LoadedConfig.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/LoadedConfig.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bonobo.Git.Server.Test.IntegrationTests
+{
+    public class LoadedConfig
+    {
+
+        private Dictionary<string, Dictionary<string, string>> _creds;
+
+        public LoadedConfig(Dictionary<string, Dictionary<string, string>> creds)
+        {
+            _creds = creds;
+                // tc.Properties["AdminCredentials"] = string.Format("{0}:{1}@", creds["admin"]["username"], creds["admin"]["password"]);
+                // tc.Properties["UserCredentials"] = string.Format("{0}:{1}@", creds["user"]["username"], creds["user"]["password"]);
+                // tc.Properties["RepositoryUrlWithCredentials"] = String.Format(RepositoryUrlTemplate, AdminCredentials, ".git", RepositoryName);
+        }
+
+        public Tuple<string, string> getCredentials(string who)
+        {
+            return new Tuple<string, string>(_creds[who]["username"], _creds[who]["password"]);
+        }
+
+        public string getUrlLogin(string who)
+        {
+            var ac = getCredentials(who);
+            return string.Format("{0}:{1}", ac.Item1, ac.Item2);
+        }
+    }
+}

--- a/Bonobo.Git.Server.Test/IntegrationTests/MiscTests.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/MiscTests.cs
@@ -8,10 +8,11 @@ using Bonobo.Git.Server.Test.IntegrationTests.Helpers;
 
 namespace Bonobo.Git.Server.Test.IntegrationTests
 {
+    using TC = TestCategories;
     [TestClass]
     public class MiscTests : IntegrationTestBase
     {
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TC.IntegrationTest), TestCategory(TC.AuthForms)]
         public void EnsureCookiePersistBetweenBrowserRestart()
         {
             app.NavigateTo<HomeController>(c => c.LogOff()); // in case the cookie is set
@@ -50,7 +51,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests
 
             MvcWebApp.Driver.Shutdown();
             app = new MvcWebApp();
-            ITH = new IntegrationTestHelpers(app);
+            ITH = new IntegrationTestHelpers(app, lc);
 
             app.NavigateTo<RepositoryController>(c => c.Index(null, null));
             app.UrlShouldMapTo<HomeController>(c => c.LogOn("/Repository/Index"));

--- a/Bonobo.Git.Server.Test/IntegrationTests/SharedLayoutTests.cs
+++ b/Bonobo.Git.Server.Test/IntegrationTests/SharedLayoutTests.cs
@@ -13,7 +13,7 @@ namespace Bonobo.Git.Server.Test.IntegrationTests
     [TestClass]
     public class SharedLayoutTests : IntegrationTestBase
     {
-        [TestMethod, TestCategory(TestCategories.WebIntegrationTest)]
+        [TestMethod, TestCategory(TestCategories.IntegrationTest)]
         public void DropdownNavigationWorks()
         {
             var reponame = ITH.MakeName();

--- a/Bonobo.Git.Server.Test/TestCategories.cs
+++ b/Bonobo.Git.Server.Test/TestCategories.cs
@@ -8,7 +8,15 @@ namespace Bonobo.Git.Server.Test
 {
     public static class TestCategories
     {
-        public const string ClAndWebIntegrationTest = "ClAndWebIntegrationTest";
-        public const string WebIntegrationTest = "WebIntegrationTest";
+        public const string IntegrationTest = "IntegrationTest";
+
+        // User data storage type
+        public const string StorageInternal = "StorageInternal";
+        public const string StorageActiveDirectory = "StorageActiveDirectory";
+
+        // Authentication types
+        public const string AuthForms = "AuthForms";
+        public const string AuthWindows = "AuthWindowsAuth";
+        public const string AuthADFS = "AuthADFS";
     }
 }

--- a/Bonobo.Git.Server.Test/app.config
+++ b/Bonobo.Git.Server.Test/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral" />

--- a/Bonobo.Git.Server.Test/example.config.json
+++ b/Bonobo.Git.Server.Test/example.config.json
@@ -1,0 +1,10 @@
+{
+  "admin": {
+    "username": "admin",
+    "password": "admin"
+  },
+  "user": {
+    "username": "hello",
+    "password": "uiae"
+  }
+}

--- a/Bonobo.Git.Server.Test/packages.config
+++ b/Bonobo.Git.Server.Test/packages.config
@@ -6,6 +6,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net451" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net451" />
   <package id="Selenium.Support" version="2.44.0" targetFramework="net451" />
   <package id="Selenium.WebDriver" version="2.44.0" targetFramework="net451" />
   <package id="Selenium.WebDriver.ChromeDriver" version="2.20.0.0" targetFramework="net451" />


### PR DESCRIPTION
This has two parts

1. If you add a config.json file to the root folder you can specify which user and password you want to use for the tests. This allows you to run Windows Auth tests without needing to create an user with username admin and password admin by using an existing user.

    An `example.config.json` has been provided.



2. Rewrite of the TestCategories.

    To be able to better specify if a tests run with a certain auth
    provider or membershipservice new TestCategories have been introduced.

    The general idea is that you should be able to exclude tests that you
    cannot run when using for example Windows Authentication because they
    require for example to create a user.

    To be able to accomplish this you should mark under what configuration
    your test can run. If it can run under any config you do not need to add
    any TestCategory.

    The old categories have been replaced by IntegrationTest as all the
    tests can be run together.
