### PR TITLE
AD: Support groups containing users from multiple domains in forest

### DIFF
--- a/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
+++ b/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
@@ -110,17 +110,17 @@ namespace Bonobo.Git.Server
         private bool IsWindowsUserAuthorized(HttpContextBase httpContext, string username, string password)
         {
             var domain = username.GetDomain();
-            username = username.StripDomain();
+            var justUsername = username.StripDomain();
             try
             {
                 using (PrincipalContext pc = new PrincipalContext(ContextType.Domain, domain))
                 {
-                    var adUser = UserPrincipal.FindByIdentity(pc, username);
+                    var adUser = UserPrincipal.FindByIdentity(pc, justUsername);
                     if (adUser != null)
                     {
-                        if (pc.ValidateCredentials(username, password, ContextOptions.Negotiate))
+                        if (pc.ValidateCredentials(justUsername, password, ContextOptions.Negotiate))
                         {
-                            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(AuthenticationProvider.GetClaimsForUser(username.Replace("\\", "!"))));
+                            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(AuthenticationProvider.GetClaimsForUser(username)));
                             return true;
                         }
                     }

--- a/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
+++ b/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
@@ -110,6 +110,7 @@ namespace Bonobo.Git.Server
         private bool IsWindowsUserAuthorized(HttpContextBase httpContext, string username, string password)
         {
             var domain = username.GetDomain();
+            if (String.IsNullOrWhiteSpace(domain)) domain = ActiveDirectorySettings.DefaultDomain;
             var justUsername = username.StripDomain();
             try
             {

--- a/Bonobo.Git.Server/Data/ADBackend.cs
+++ b/Bonobo.Git.Server/Data/ADBackend.cs
@@ -173,8 +173,8 @@ namespace Bonobo.Git.Server.Data
 
                 foreach (var domain in allDomains)
                 {
-                    var gitUsers = (gitUsersByDomain.Contains(domain) ? gitUsersByDomain[domain].ToArray() : new UserModel[] {}).ToDictionary(x=>x.Username, StringComparer.OrdinalIgnoreCase);
-                    var groupUsers = new HashSet<string>(groupUsersByDomain.Contains(domain) ? groupUsersByDomain[domain].ToArray() : new string[] {});
+                    var gitUsers = gitUsersByDomain[domain].ToDictionary(x=>x.Username, StringComparer.OrdinalIgnoreCase);
+                    var groupUsers = new HashSet<string>(groupUsersByDomain[domain], StringComparer.OrdinalIgnoreCase);
 
                     foreach (var gitUser in gitUsers.Values.Where(x=>!groupUsers.Contains(x.Username)))
                     {

--- a/Bonobo.Git.Server/Data/ADBackend.cs
+++ b/Bonobo.Git.Server/Data/ADBackend.cs
@@ -159,23 +159,43 @@ namespace Bonobo.Git.Server.Data
 
         private void UpdateUsers()
         {
+            var gitUsersByDomain = Users.ToLookup(x => x.Username.GetDomain(), StringComparer.OrdinalIgnoreCase);
             try
             {
+                ILookup<string, string> groupUsersByDomain;
                 using (PrincipalContext principalContext = new PrincipalContext(ContextType.Domain, ActiveDirectorySettings.DefaultDomain))
                 using (GroupPrincipal memberGroup = GetMembersGroup(principalContext))
                 {
-                    foreach (Guid Id in Users.Select(x => x.Id).Where(x => UserPrincipal.FindByIdentity(principalContext, IdentityType.Guid, x.ToString()) == null))
+                    groupUsersByDomain = memberGroup.GetMembers(true).OfType<UserPrincipal>().Select(x => x.UserPrincipalName).Where(x => x != null).ToLookup(x=>x.GetDomain(), StringComparer.OrdinalIgnoreCase);
+                }
+
+                var allDomains = groupUsersByDomain.Select(x=>x.Key).Union(gitUsersByDomain.Select(x=>x.Key)).Distinct(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var domain in allDomains)
+                {
+                    var gitUsers = (gitUsersByDomain.Contains(domain) ? gitUsersByDomain[domain].ToArray() : new UserModel[] {}).ToDictionary(x=>x.Username, StringComparer.OrdinalIgnoreCase);
+                    var groupUsers = new HashSet<string>(groupUsersByDomain.Contains(domain) ? groupUsersByDomain[domain].ToArray() : new string[] {});
+
+                    foreach (var gitUser in gitUsers.Values.Where(x=>!groupUsers.Contains(x.Username)))
                     {
-                        Users.Remove(Id);
+                        Users.Remove(gitUser);
                     }
-                    foreach (string username in memberGroup.GetMembers(true).OfType<UserPrincipal>().Select(x => x.UserPrincipalName).Where(x => x != null))
-                    {
-                        using (UserPrincipal principal = UserPrincipal.FindByIdentity(principalContext, IdentityType.UserPrincipalName, username))
+
+                    using (PrincipalContext principalContext = new PrincipalContext(ContextType.Domain, domain))
+                    { 
+                        foreach (var groupUser in groupUsers)
                         {
-                            UserModel user = GetUserModelFromPrincipal(principal);
-                            if (user != null)
+                            using (var principal = UserPrincipal.FindByIdentity(principalContext, IdentityType.UserPrincipalName, groupUser))
                             {
-                                Users.AddOrUpdate(user);
+                                UserModel user = GetUserModelFromPrincipal(principal);
+                                if (user != null)
+                                {
+                                    Users.AddOrUpdate(user);
+                                }
+                                else if(gitUsers.ContainsKey(groupUser))
+                                {
+                                    Users.Remove(gitUsers[groupUser]);
+                                }
                             }
                         }
                     }

--- a/Bonobo.Git.Server/Data/Update/SqlServer/AddGuidColumn.cs
+++ b/Bonobo.Git.Server/Data/Update/SqlServer/AddGuidColumn.cs
@@ -277,7 +277,7 @@ namespace Bonobo.Git.Server.Data.Update.SqlServer
                         dc = new PrincipalContext(ContextType.Domain, domain);
                         domains[domain] = dc;
                     }
-                    var user = UserPrincipal.FindByIdentity(dc, entry.Username);
+                    var user = UserPrincipal.FindByIdentity(dc, IdentityType.UserPrincipalName, entry.Username);
                     // if the user no longer exists
                     // it means he cannot login anymore so it is safe to assign
                     // any new guid to him

--- a/Bonobo.Git.Server/Data/Update/Sqlite/AddGuidColumn.cs
+++ b/Bonobo.Git.Server/Data/Update/Sqlite/AddGuidColumn.cs
@@ -272,7 +272,7 @@ namespace Bonobo.Git.Server.Data.Update.Sqlite
                         dc = new PrincipalContext(ContextType.Domain, domain);
                         domains[domain] = dc;
                     }
-                    var user = UserPrincipal.FindByIdentity(dc, entry.Username);
+                    var user = UserPrincipal.FindByIdentity(dc, IdentityType.UserPrincipalName, entry.Username);
                     // if the user no longer exists
                     // it means he cannot login anymore so it is safe to assign
                     // any new guid to him


### PR DESCRIPTION
Hi,

These changes are working here against our AD setup.  Changes fall into two camps:
- for user operations, pass around domain+username, and consistently use the given domain or the default to look up the user;
- for UpdateUsers in ADBackend, once you have looked up the group look up the user against the expected domain

I don't have good visibility on how to make it more generic within the structure of the app.  Also, should the groups not be in the default domain then AD will still have problems.  The only solution to that would be to require all the config groups to be in domain\group format which has backwards compat issues that you might not want.

Two other things:
- I cannot get the personal url to work.  I am not sure whether that is because of AD or the newer version of the code but I don't have a readily-available setup that I'm confident of.  I suspect double @ in the url is causing the problem.
- When I upgraded my instance, I got a error from sqllite about adding a guid column when it went to update.  I just removed the db and it worked, but looking through the code I think it was because CopyUsers was not specifically using UserPrincipalName and AD was getting confused.  However I had no old data to test

Hope that all makes sense, let me know if not and I can adjust things
