### PR TITLE
[WIP] Update the ADBackend information when updating from pre 6.0

### DIFF
--- a/Bonobo.Git.Server.Test/MembershipTests/ADTests/ADBackendStoreTest.cs
+++ b/Bonobo.Git.Server.Test/MembershipTests/ADTests/ADBackendStoreTest.cs
@@ -69,7 +69,7 @@ namespace Bonobo.Git.Server.Test.MembershipTests.ADTests
         [TestMethod]
         public void ItemCanBeAddedToStoreAndRetrievedViaDisk()
         {
-            _store.Add(new StorableClass { Name = "Hello" });
+            _store.Add(new StorableClass { Name = "Hello", Id = Guid.NewGuid() });
 
             var loadStore = MakeStore();
             var retrieved = loadStore.Single();
@@ -161,6 +161,11 @@ namespace Bonobo.Git.Server.Test.MembershipTests.ADTests
             public Guid Id { get; set; }
             public string Name { get; set; }
             public string DisplayName { get { return Name; } }
+
+            public StorableClass()
+            {
+                Id = Guid.NewGuid();
+            }
         }
     }
 }

--- a/Bonobo.Git.Server.Test/MembershipTests/ADTests/ADPermissionServiceTest.cs
+++ b/Bonobo.Git.Server.Test/MembershipTests/ADTests/ADPermissionServiceTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Bonobo.Git.Server.Data;
 using Bonobo.Git.Server.Models;
 using Bonobo.Git.Server.Security;
@@ -38,7 +39,7 @@ namespace Bonobo.Git.Server.Test.MembershipTests.ADTests
 
         protected override TeamModel CreateTeam()
         {
-            var newTeam = new TeamModel { Name = "Team1" };
+            var newTeam = new TeamModel { Name = "Team1", Id = Guid.NewGuid() };
             newTeam.Members = new UserModel[0];
             ADBackend.Instance.Teams.Add(newTeam);
             return newTeam;

--- a/Bonobo.Git.Server.Test/MembershipTests/ADTests/ADRepositoryRepositoryServiceTest.cs
+++ b/Bonobo.Git.Server.Test/MembershipTests/ADTests/ADRepositoryRepositoryServiceTest.cs
@@ -30,7 +30,7 @@ namespace Bonobo.Git.Server.Test.MembershipTests.ADTests
 
         protected override TeamModel AddTeam()
         {
-            var newTeam = new TeamModel { Name = "Team1"};
+            var newTeam = new TeamModel { Name = "Team1", Id = Guid.NewGuid()};
             ADBackend.Instance.Teams.Add(newTeam);
             return newTeam;
         }

--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -126,6 +126,7 @@
       <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
@@ -257,6 +258,8 @@
     <Compile Include="Data\ADTeamRepository.cs" />
     <Compile Include="Data\DatabaseResetManager.cs" />
     <Compile Include="Data\INameProperty.cs" />
+    <Compile Include="Data\Update\ADBackend\ADBackendPre6.0.0Models.cs" />
+    <Compile Include="Data\Update\ADBackend\UpdateADBackend.cs" />
     <Compile Include="Data\Update\Sqlite\AddGroup.cs" />
     <Compile Include="Data\Update\Sqlite\AddGuidColumn.cs" />
     <Compile Include="Data\Update\Sqlite\AddRepoPushColumn.cs" />

--- a/Bonobo.Git.Server/Data/ADBackend.cs
+++ b/Bonobo.Git.Server/Data/ADBackend.cs
@@ -43,9 +43,22 @@ namespace Bonobo.Git.Server.Data
 
         public static void ResetSingletonForTesting()
         {
+            ResetSingletonWithoutAutomaticUpdate();
+        }
+
+        public static void ResetSingletonWithoutAutomaticUpdate()
+        {
             lock (instanceLock)
             {
                 instance = new ADBackend(false);
+            }
+        }
+
+        public static void ResetSingletonWithAutomaticUpdate()
+        {
+            lock (instanceLock)
+            {
+                instance = new ADBackend(true);
             }
         }
 

--- a/Bonobo.Git.Server/Data/ADBackendStore.cs
+++ b/Bonobo.Git.Server/Data/ADBackendStore.cs
@@ -158,17 +158,7 @@ namespace Bonobo.Git.Server.Data
 
         private string GetItemFilename(T item)
         {
-            StringBuilder result = new StringBuilder(45);
-
-            byte[] hash = SHA1.Create().ComputeHash(Encoding.UTF8.GetBytes(item.Name));
-            for (int i = 0; i < hash.Length; i++)
-            {
-                result.Append(hexchars[hash[i] >> 4]);
-                result.Append(hexchars[hash[i] & 0x0f]);
-            }
-            result.Append(".json");
-
-            return result.ToString();
+            return item.Id+".json";
         }
     }
 }

--- a/Bonobo.Git.Server/Data/ADBackendStore.cs
+++ b/Bonobo.Git.Server/Data/ADBackendStore.cs
@@ -12,6 +12,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Web.Hosting;
 using Bonobo.Git.Server.Configuration;
+using Bonobo.Git.Server.Helpers;
 
 namespace Bonobo.Git.Server.Data
 {
@@ -40,7 +41,7 @@ namespace Bonobo.Git.Server.Data
 
         public ADBackendStore(string rootpath, string name)
         {
-            _storagePath = Path.Combine(GetRootPath(rootpath), name);
+            _storagePath = Path.Combine(PathEncoder.GetRootPath(rootpath), name);
             _content = LoadContent();
         }
 
@@ -144,11 +145,6 @@ namespace Bonobo.Git.Server.Data
             }
 
             return result;
-        }
-
-        private string GetRootPath(string path)
-        {
-            return Path.IsPathRooted(path) ? path : HostingEnvironment.MapPath(path);
         }
 
         private string GetItemFilename(T item)

--- a/Bonobo.Git.Server/Data/ADBackendStore.cs
+++ b/Bonobo.Git.Server/Data/ADBackendStore.cs
@@ -47,6 +47,10 @@ namespace Bonobo.Git.Server.Data
 
         public bool Add(T item)
         {
+            if (item.Id == Guid.Empty)
+            {
+                throw new ArgumentException("You must set the Id before adding an item");
+            }
             return _content.TryAdd(item.Id, item) && Store(item);
         }
 
@@ -88,6 +92,11 @@ namespace Bonobo.Git.Server.Data
 
         private bool Store(T item)
         {
+            if (item.Id == Guid.Empty)
+            {
+                throw new ArgumentException("Item does not have a proper Id");
+            }
+
             bool result = false;
 
             try

--- a/Bonobo.Git.Server/Data/Update/ADBackend/ADBackendPre6.0.0Models.cs
+++ b/Bonobo.Git.Server/Data/Update/ADBackend/ADBackendPre6.0.0Models.cs
@@ -1,0 +1,85 @@
+﻿
+using Newtonsoft.Json;
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+
+namespace Bonobo.Git.Server.Data.Update.Pre600ADBackend
+{
+    public interface Pre600INameProperty
+    {
+        string Name { get; }
+    }
+
+    // These models were used pre 6.0.0
+    public class Pre600RoleModel : Pre600INameProperty
+    {
+        public string Name { get; set; }
+        public string[] Members { get; set; }
+    }
+
+    public class Pre600UserModel : Pre600INameProperty
+    {
+        public string Name { get; set; }
+        public string GivenName { get; set; }
+        public string Surname { get; set; }
+        public string Email { get; set; }
+
+        public string DisplayName
+        {
+            get
+            {
+                return String.Format("{0} {1}", GivenName, Surname);
+            }
+        }
+    }
+
+    public class Pre600TeamModel : Pre600INameProperty
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string[] Members { get; set; }
+    }
+
+
+    public class Pre600RepositoryModel : Pre600INameProperty
+    {
+        public string Name { get; set; }
+        public string Group { get; set; }
+        public string Description { get; set; }
+        public bool AnonymousAccess { get; set; }
+        public string[] Users { get; set; }
+        public string[] Administrators { get; set; }
+        public string[] Teams { get; set; }
+        public bool AuditPushUser { get; set; }
+        public byte[] Logo { get; set; }
+        public bool RemoveLogo { get; set; }
+    }
+
+    public class Pre600Functions
+    {
+        public static ConcurrentDictionary<string, T> LoadContent<T>(string storagePath) where T : Pre600INameProperty
+        {
+            ConcurrentDictionary<string, T> result = new ConcurrentDictionary<string, T>();
+
+            if (!Directory.Exists(storagePath))
+            {
+                Directory.CreateDirectory(storagePath);
+            }
+
+            foreach (string filename in Directory.EnumerateFileSystemEntries(storagePath, "*.json"))
+            {
+                try
+                {
+                    T item = JsonConvert.DeserializeObject<T>(File.ReadAllText(filename));
+                    result.TryAdd(item.Name, item);
+                }
+                catch
+                {
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/Bonobo.Git.Server/Data/Update/ADBackend/UpdateADBackend.cs
+++ b/Bonobo.Git.Server/Data/Update/ADBackend/UpdateADBackend.cs
@@ -141,6 +141,7 @@ namespace Bonobo.Git.Server.Data.Update.ADBackendUpdate
             {
                 var repo = repoitem.Value;
                 var newrepo = new Models.RepositoryModel();
+                newrepo.Id = Guid.NewGuid();
                 newrepo.Name = repo.Name;
                 newrepo.Group = repo.Group;
                 newrepo.Description = repo.Description;
@@ -246,7 +247,7 @@ namespace Bonobo.Git.Server.Data.Update.ADBackendUpdate
                 }
 
                 var domainuser = UserPrincipal.FindByIdentity(dc, u.Username);
-                if (domainuser != null)
+                if (domainuser != null && domainuser.Guid.HasValue)
                 {
                     u.Id = domainuser.Guid.Value;
                 }

--- a/Bonobo.Git.Server/Data/Update/ADBackend/UpdateADBackend.cs
+++ b/Bonobo.Git.Server/Data/Update/ADBackend/UpdateADBackend.cs
@@ -1,0 +1,156 @@
+﻿using Bonobo.Git.Server.Data.Update.Pre600ADBackend;
+using System.IO;
+using Bonobo.Git.Server.Helpers;
+using System.Collections.Generic;
+using System.DirectoryServices.AccountManagement;
+using Bonobo.Git.Server.Configuration;
+using System;
+
+namespace Bonobo.Git.Server.Data.Update.ADBackendUpdate
+{
+    public class Pre600UpdateTo600
+    {
+        // Before 6.0.0 the mapping was done via the name property. After that the Guid is used.
+        public static void UpdateADBackend()
+        {
+            // Make a copy of the current backendfolder if it exists, so we can use the modern models for saving
+            // it all to the correct location directly
+            var dir = PathEncoder.GetRootPath(ActiveDirectorySettings.BackendPath);
+            var bkpdir = PathEncoder.GetRootPath(ActiveDirectorySettings.BackendPath + "_pre6.0.0");
+            if (Directory.Exists(dir))
+            {
+                if (!Directory.Exists(bkpdir))
+                {
+                    new Microsoft.VisualBasic.Devices.Computer().FileSystem.CopyDirectory(dir, bkpdir);
+                }
+
+                // We must create one that will not automatically update the items while we update them
+                ADBackend.ResetSingletonWithoutAutomaticUpdate();
+
+                var newUsers = UpdateUsers(Path.Combine(bkpdir, "Users"));
+                var newTeams = UpdateTeams(Path.Combine(bkpdir, "Teams"), newUsers);
+                UpdateRoles(Path.Combine(bkpdir, "Roles"), newUsers);
+                UpdateRepos(Path.Combine(bkpdir, "Repos"), newUsers, newTeams);
+
+                ADBackend.ResetSingletonWithAutomaticUpdate();
+            }
+        }
+
+        private static void UpdateRepos(string dir, Dictionary<string, Models.UserModel> users, Dictionary<string, Models.TeamModel> teams)
+        {
+            var repos = Pre600Functions.LoadContent<Pre600RepositoryModel>(dir);
+            foreach(var repoitem in repos)
+            {
+                var repo = repoitem.Value;
+                var newrepo = new Models.RepositoryModel();
+                newrepo.Name = repo.Name;
+                newrepo.Group = repo.Group;
+                newrepo.Description = repo.Description;
+                newrepo.AnonymousAccess = repo.AnonymousAccess;
+                newrepo.AuditPushUser = repo.AuditPushUser;
+                newrepo.Logo = repo.Logo;
+                newrepo.RemoveLogo = repo.RemoveLogo;
+
+                var list = new List<Models.UserModel>();
+                foreach (var user in repo.Users)
+                {
+                    list.Add(users[user]);
+                }
+                newrepo.Users = list.ToArray();
+
+                list.Clear();
+                foreach(var admins in repo.Administrators)
+                {
+                    list.Add(users[admins]);
+                }
+                newrepo.Administrators = list.ToArray();
+
+                var newteams = new List<Models.TeamModel>();
+                foreach(var team in repo.Teams)
+                {
+                    newteams.Add(teams[team]);
+                }
+                newrepo.Teams = newteams.ToArray();
+
+                ADBackend.Instance.Repositories.Add(newrepo);
+            }
+        }
+
+        private static void UpdateRoles(string dir, Dictionary<string, Models.UserModel> users)
+        {
+            var roles = Pre600Functions.LoadContent<Pre600RoleModel>(dir);
+            foreach(var roleitem in roles)
+            {
+                var role = roleitem.Value;
+                var newrole = new Models.RoleModel();
+                newrole.Name = role.Name;
+
+                newrole.Id = Guid.NewGuid();
+                var members = new List<Guid>();
+                foreach (var member in role.Members) {
+                    members.Add(users[member].Id);
+                }
+            }
+        }
+
+        private static Dictionary<string, Models.TeamModel> UpdateTeams(string dir, Dictionary<string, Models.UserModel> users)
+        {
+            var teams = Pre600Functions.LoadContent<Pre600TeamModel>(dir);
+            var newTeams = new Dictionary<string, Models.TeamModel>();
+            foreach(var teamitem in teams)
+            {
+                var team = teamitem.Value;
+                var newteam = new Models.TeamModel();
+                newteam.Name = team.Name;
+                newteam.Description = team.Description;
+
+                newteam.Id = Guid.NewGuid();
+                var members = new List<Models.UserModel>();
+                foreach (var member in team.Members)
+                {
+                    members.Add(users[member]);
+                }
+                newteam.Members = members.ToArray();
+
+                ADBackend.Instance.Teams.Add(newteam);
+                newTeams[team.Name] = newteam;
+            }
+            return newTeams;
+        }
+
+        private static Dictionary<string, Models.UserModel> UpdateUsers(string dir)
+        {
+            var users = Pre600Functions.LoadContent<Pre600UserModel>(dir);
+            var domains = new Dictionary<string, PrincipalContext>();
+            var newUsers = new Dictionary<string, Models.UserModel>();
+            foreach (var user in users)
+            {
+                var ou = user.Value;
+                var u = new Models.UserModel();
+                u.Email = ou.Email;
+                u.GivenName = ou.GivenName;
+                u.Surname = ou.Surname;
+                u.Username = ou.Name;
+                u.Id = Guid.NewGuid();
+
+                PrincipalContext dc;
+                var domain = u.Username.GetDomain();
+                if (!domains.TryGetValue(domain, out dc))
+                {
+                    dc = new PrincipalContext(ContextType.Domain, domain);
+                    domains[domain] = dc;
+                }
+
+                var domainuser = UserPrincipal.FindByIdentity(dc, u.Username);
+                if (domainuser != null)
+                {
+                    u.Id = domainuser.Guid.Value;
+                }
+
+                ADBackend.Instance.Users.Add(u);
+                newUsers[u.Username] = u;
+            }
+            return newUsers;
+        }
+    }
+}

--- a/Bonobo.Git.Server/Data/Update/ADBackend/UpdateADBackend.cs
+++ b/Bonobo.Git.Server/Data/Update/ADBackend/UpdateADBackend.cs
@@ -185,9 +185,15 @@ namespace Bonobo.Git.Server.Data.Update.ADBackendUpdate
 
                 newrole.Id = Guid.NewGuid();
                 var members = new List<Guid>();
-                foreach (var member in role.Members) {
-                    members.Add(users[member].Id);
+                foreach (var memberName in role.Members)
+                {
+                    Models.UserModel user;
+                    if (users.TryGetValue(memberName, out user))
+                    {
+                        members.Add(user.Id);
+                    }
                 }
+                newrole.Members = members.ToArray();
             }
         }
 

--- a/Bonobo.Git.Server/Data/Update/AutomaticUpdater.cs
+++ b/Bonobo.Git.Server/Data/Update/AutomaticUpdater.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Bonobo.Git.Server.Configuration;
+using Bonobo.Git.Server.Data.Update.ADBackendUpdate;
+using System;
 using System.Data.Entity.Infrastructure;
 using System.Diagnostics;
 using System.Linq;
@@ -9,7 +11,14 @@ namespace Bonobo.Git.Server.Data.Update
     {
         public void Run()
         {
-            UpdateDatabase();
+            if (AuthenticationSettings.MembershipService.ToLowerInvariant() == "activedirectory")
+            {
+                Pre600UpdateTo600.UpdateADBackend();
+            }
+            else
+            {
+                UpdateDatabase();
+            }
         }
 
         public void RunWithContext(BonoboGitServerContext context)

--- a/Bonobo.Git.Server/Helpers/PathEncoder.cs
+++ b/Bonobo.Git.Server/Helpers/PathEncoder.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Text;
+using System.Web.Hosting;
 
 namespace Bonobo.Git.Server.Helpers
 {
@@ -114,6 +116,11 @@ namespace Bonobo.Git.Server.Helpers
             }
             // Return decoded string
             return Encoding.UTF8.GetString(bytes.ToArray());
+        }
+
+        public static string GetRootPath(string path)
+        {
+            return Path.IsPathRooted(path) ? path : HostingEnvironment.MapPath(path);
         }
     }
 }


### PR DESCRIPTION
Hopefully this fixes the problems for ActiveDirectory users that lost all their data when updating to the unreleased 6.0 version.

To test if it works: Checkout/install version 5.2 create some repos/teams. Checkout this branch and see if you can see the repos/teams with all their informations/members correctly.

@willdean Can you give this a spin? 
@chrismdev Can you give this a spin? 