### PR TITLE
Fix LDAP authentication issues on push

### DIFF
--- a/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
+++ b/Bonobo.Git.Server/Attributes/GitAuthorizeAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Security.Claims;
 using System.Text;
@@ -7,6 +7,7 @@ using System.Web.Mvc;
 using System.DirectoryServices.AccountManagement;
 using Bonobo.Git.Server.Data;
 using Bonobo.Git.Server.Security;
+using Bonobo.Git.Server.Configuration;
 
 using Microsoft.Practices.Unity;
 
@@ -109,11 +110,10 @@ namespace Bonobo.Git.Server
 
         private bool IsWindowsUserAuthorized(HttpContextBase httpContext, string username, string password)
         {
-            var domain = username.GetDomain();
             username = username.StripDomain();
             try
             {
-                using (PrincipalContext pc = new PrincipalContext(ContextType.Domain, domain))
+                using (PrincipalContext pc = new PrincipalContext(ContextType.Domain, ActiveDirectorySettings.DefaultDomain))
                 {
                     var adUser = UserPrincipal.FindByIdentity(pc, username);
                     if (adUser != null)


### PR DESCRIPTION
The user should be able to use a shortened domain name (e.g. contoso\username instead of contoso.com\username) when logging on to the server via NTLM/LDAP. This works fine for the web interface, but produces 401 errors when trying to push changes to Git. We already have a setting for the full domain name in the web.config, which is used in other parts of the system. There's no reason to try and guess the domain name by taking apart the username.
