### PR TITLE
Remove InstalledUICulture override of date formatting

### DIFF
--- a/Bonobo.Git.Server/Models/RepositoryModels.cs
+++ b/Bonobo.Git.Server/Models/RepositoryModels.cs
@@ -174,7 +174,7 @@ namespace Bonobo.Git.Server.Models
 
         [Display(ResourceType = typeof(Resources), Name = "Repository_Tree_CommitDate")]
         public DateTime? CommitDate { get; set; }
-        public string CommitDateString { get { return CommitDate.HasValue ? CommitDate.Value.ToString(CultureInfo.InstalledUICulture) : CommitDate.ToString(); } }
+        public string CommitDateString { get { return CommitDate.HasValue ? CommitDate.Value.ToString() : CommitDate.ToString(); } }
 
         [Display(ResourceType = typeof(Resources), Name = "Repository_Tree_Author")]
         public string Author { get; set; }

--- a/Bonobo.Git.Server/Views/Repository/_Commit.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/_Commit.cshtml
@@ -12,7 +12,7 @@
         </h2>
 
         <div class="commitdate">
-            @Model.Date.ToString(CultureInfo.InstalledUICulture)
+            @Model.Date.ToString()
         </div>
         @if (Model.Links.Count() > 0)
         {

--- a/Bonobo.Git.Server/Views/Repository/_Tag.cshtml
+++ b/Bonobo.Git.Server/Views/Repository/_Tag.cshtml
@@ -17,7 +17,7 @@
             }
         </h2>
         <div class="commitdate">
-            @Model.Date.ToString(CultureInfo.InstalledUICulture)
+            @Model.Date.ToString()
         </div>
         @if (UserConfiguration.Current.HasLinks)
         {


### PR DESCRIPTION
Let the date formatting use the current thread culture, and if that's wrong we'll investigate why.  Addresses #616 where nothing in the IIS/ASP.NET culture settings was having an effect.


