### PR TITLE
Allow to use c#6 with old visual studio

### DIFF
--- a/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
+++ b/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -228,6 +229,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.99.0\build\net45\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.99.0\build\net45\System.Data.SQLite.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets. -->

--- a/Bonobo.Git.Server.Test/packages.config
+++ b/Bonobo.Git.Server.Test/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.AspNet.Mvc.Futures" version="5.0.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net451" />
+  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net451" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net451" />
   <package id="Selenium.Support" version="2.44.0" targetFramework="net451" />

--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -752,5 +753,6 @@ if not exist "$(TargetDir)\x64" md "$(TargetDir)\x64"
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.99.0\build\net45\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.99.0\build\net45\System.Data.SQLite.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
   </Target>
 </Project>

--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj.DotSettings
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj.DotSettings
@@ -1,2 +1,2 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String></wpf:ResourceDictionary>

--- a/Bonobo.Git.Server/Data/Update/UpdateScriptRepository.cs
+++ b/Bonobo.Git.Server/Data/Update/UpdateScriptRepository.cs
@@ -39,7 +39,7 @@ namespace Bonobo.Git.Server.Data.Update
                         new SqlServer.InsertDefaultData()
                     };
                 default:
-                    throw new NotImplementedException(string.Format("The provider '{0}' is not supported yet", sqlProvider));
+                    throw new NotImplementedException($"The provider '{sqlProvider}' is not supported yet");
             }
         }
     }

--- a/Bonobo.Git.Server/Extensions/LinqExtensions.cs
+++ b/Bonobo.Git.Server/Extensions/LinqExtensions.cs
@@ -8,6 +8,9 @@ namespace Bonobo.Git.Server
     {
         public static IEnumerable<T> OrderBy<T, TKey>(this IEnumerable<T> source, Func<T, TKey> selector, bool ascending)
         {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
             if (ascending)
             {
                 return source.OrderBy(selector);

--- a/Bonobo.Git.Server/packages.config
+++ b/Bonobo.Git.Server/packages.config
@@ -13,6 +13,7 @@
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.2.206221351" targetFramework="net45" />
+  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net45" />


### PR DESCRIPTION
Now, we can use `string interpolation`, `nameof `and `other c#6` features with back compatibility with old Visual Studio.
The Microsoft.Net.Compilers nuget package embed the roslyn compiler and replace the default one.