### PR TITLE
Revert System.IdentityModel.Tokens.Jwt to version 4.

### DIFF
--- a/Bonobo.Git.Server.Test/app.config
+++ b/Bonobo.Git.Server.Test/app.config
@@ -40,7 +40,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.1.3.0" newVersion="5.1.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.40306.1554" newVersion="4.0.40306.1554" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Protocol.Extensions" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -196,8 +196,8 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.1.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.1.3\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.40306.1554, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.4.0.4.403061554\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Compression" />

--- a/Bonobo.Git.Server/packages.config
+++ b/Bonobo.Git.Server/packages.config
@@ -34,7 +34,7 @@
   <package id="System.Data.SQLite.Core" version="1.0.104.0" targetFramework="net46" />
   <package id="System.Data.SQLite.EF6" version="1.0.104.0" targetFramework="net46" />
   <package id="System.Data.SQLite.Linq" version="1.0.104.0" targetFramework="net46" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="5.1.3" targetFramework="net46" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.4.403061554" targetFramework="net46" />
   <package id="UDE.CSharp" version="1.1.0" targetFramework="net45" />
   <package id="Unity" version="4.0.1" targetFramework="net45" />
   <package id="Unity.Mvc" version="4.0.1" targetFramework="net45" />

--- a/Bonobo.Git.Server/web.config
+++ b/Bonobo.Git.Server/web.config
@@ -113,7 +113,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.1.3.0" newVersion="5.1.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.40306.1554" newVersion="4.0.40306.1554" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Protocol.Extensions" publicKeyToken="31bf3856ad364e35" culture="neutral" />


### PR DESCRIPTION
5.x versions of this library don't work properly with ASP.NET.

This addresses the main issue in #681