### PR TITLE
Allow Custom CSS URLs

### DIFF
--- a/Bonobo.Git.Server/App_GlobalResources/Resources.Designer.cs
+++ b/Bonobo.Git.Server/App_GlobalResources/Resources.Designer.cs
@@ -2129,6 +2129,24 @@ namespace Bonobo.Git.Server.App_GlobalResources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Site CSS URL.
+        /// </summary>
+        public static string Settings_Global_SiteCssUrl {
+            get {
+                return ResourceManager.GetString("Settings_Global_SiteCssUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to URL to a CSS file to use for the site.  Site-relative (~) paths are supported..
+        /// </summary>
+        public static string Settings_Global_SiteCssUrl_Hint {
+            get {
+                return ResourceManager.GetString("Settings_Global_SiteCssUrl_Hint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Site Footer Message.
         /// </summary>
         public static string Settings_Global_SiteFooterMessage {

--- a/Bonobo.Git.Server/App_GlobalResources/Resources.resx
+++ b/Bonobo.Git.Server/App_GlobalResources/Resources.resx
@@ -951,4 +951,10 @@ The regular C# string formatting rules apply: To get {} in your link you need to
   <data name="Home_About_Title" xml:space="preserve">
     <value>About</value>
   </data>
+  <data name="Settings_Global_SiteCssUrl" xml:space="preserve">
+    <value>Site CSS URL</value>
+  </data>
+  <data name="Settings_Global_SiteCssUrl_Hint" xml:space="preserve">
+    <value>URL to a CSS file to use for the site.  Site-relative (~) paths are supported.</value>
+  </data>
 </root>

--- a/Bonobo.Git.Server/Configuration/UserConfiguration.cs
+++ b/Bonobo.Git.Server/Configuration/UserConfiguration.cs
@@ -22,6 +22,7 @@ namespace Bonobo.Git.Server.Configuration
         public string SiteTitle { get; set; }
         public string SiteLogoUrl { get; set; }
         public string SiteFooterMessage { get; set; }
+        public string SiteCssUrl { get; set; }
         public bool IsCommitAuthorAvatarVisible { get; set; }
         public string LinksRegex { get; set; }
         public string LinksUrl { get; set; }
@@ -50,6 +51,11 @@ namespace Bonobo.Git.Server.Configuration
             {
                 return !string.IsNullOrWhiteSpace(this.SiteLogoUrl);
             }
+        }
+
+        public bool HasCustomSiteCss
+        {
+            get { return !string.IsNullOrWhiteSpace(SiteCssUrl); }
         }
 
         public bool HasLinks

--- a/Bonobo.Git.Server/Controllers/SettingsController.cs
+++ b/Bonobo.Git.Server/Controllers/SettingsController.cs
@@ -29,6 +29,7 @@ namespace Bonobo.Git.Server.Controllers
                 SiteTitle = UserConfiguration.Current.SiteTitle,
                 SiteLogoUrl = UserConfiguration.Current.SiteLogoUrl,
                 SiteFooterMessage = UserConfiguration.Current.SiteFooterMessage,
+                SiteCssUrl = UserConfiguration.Current.SiteCssUrl,
                 IsCommitAuthorAvatarVisible = UserConfiguration.Current.IsCommitAuthorAvatarVisible,
                 LinksRegex = UserConfiguration.Current.LinksRegex,
                 LinksUrl = UserConfiguration.Current.LinksUrl,
@@ -62,6 +63,7 @@ namespace Bonobo.Git.Server.Controllers
                         UserConfiguration.Current.SiteTitle = model.SiteTitle;
                         UserConfiguration.Current.SiteLogoUrl = model.SiteLogoUrl;
                         UserConfiguration.Current.SiteFooterMessage = model.SiteFooterMessage;
+                        UserConfiguration.Current.SiteCssUrl = model.SiteCssUrl;
                         UserConfiguration.Current.IsCommitAuthorAvatarVisible = model.IsCommitAuthorAvatarVisible;
                         UserConfiguration.Current.LinksRegex = model.LinksRegex;
                         UserConfiguration.Current.LinksUrl = model.LinksUrl;

--- a/Bonobo.Git.Server/Models/SettingsModels.cs
+++ b/Bonobo.Git.Server/Models/SettingsModels.cs
@@ -39,6 +39,9 @@ namespace Bonobo.Git.Server.Models
         [Display(ResourceType = typeof(Resources), Name = "Settings_Global_SiteFooterMessage")]
         public string SiteFooterMessage { get; set; }
 
+        [Display(ResourceType = typeof(Resources), Name = "Settings_Global_SiteCssUrl")]
+        public string SiteCssUrl { get; set; }
+
         [Display(ResourceType = typeof(Resources), Name = "Settings_Global_IsCommitAuthorAvatarVisible")]
         public bool IsCommitAuthorAvatarVisible { get; set; }
 

--- a/Bonobo.Git.Server/Views/Settings/Index.cshtml
+++ b/Bonobo.Git.Server/Views/Settings/Index.cshtml
@@ -42,6 +42,11 @@
             <i class="fa fa-info-circle" title="@Resources.Settings_Global_SiteFooterMessage_Hint"></i>
         </div>
         <div class="pure-control-group">
+            @Html.LabelFor(m => m.SiteCssUrl)
+            @Html.TextBoxFor(m => m.SiteCssUrl, new { @class = "medium", autofocus = "" })
+            <i class="fa fa-info-circle" title="@Resources.Settings_Global_SiteCssUrl_Hint"></i>
+        </div>
+        <div class="pure-control-group">
             @Html.LabelFor(m => m.DefaultLanguage)
             @Html.DropDownListFor(m => m.DefaultLanguage, 
                 CultureInfo.GetCultures(CultureTypes.SpecificCultures).Select(

--- a/Bonobo.Git.Server/Views/Shared/_Layout.cshtml
+++ b/Bonobo.Git.Server/Views/Shared/_Layout.cshtml
@@ -5,6 +5,10 @@
     <link rel="shortcut icon" href="~/favicon.ico?v=2" type="image/x-icon" />
     <title>@ViewBag.Title :: @UserConfiguration.Current.GetSiteTitle()</title>
     @Styles.Render("~/Content/bundledCss")
+    @if (UserConfiguration.Current.HasCustomSiteCss)
+    {
+        <link rel="stylesheet" href="@Url.Content(@UserConfiguration.Current.SiteCssUrl)@(string.Format("?_={0}", DateTime.Now.Ticks))" type="text/css" />
+    }
     @if (UserConfiguration.Current.HasCustomSiteLogo)
     {
     <style>

--- a/Bonobo.Git.Server/Views/Shared/_Layout.cshtml
+++ b/Bonobo.Git.Server/Views/Shared/_Layout.cshtml
@@ -7,7 +7,7 @@
     @Styles.Render("~/Content/bundledCss")
     @if (UserConfiguration.Current.HasCustomSiteCss)
     {
-        <link rel="stylesheet" href="@Url.Content(@UserConfiguration.Current.SiteCssUrl)@(string.Format("?_={0}", DateTime.Now.Ticks))" type="text/css" />
+        <link rel="stylesheet" href="@string.Format("{0}?_={1}", Url.Content(UserConfiguration.Current.SiteCssUrl), DateTime.Now.Ticks)" type="text/css" />
     }
     @if (UserConfiguration.Current.HasCustomSiteLogo)
     {


### PR DESCRIPTION
To allow for further customisation beyond the Logo, Title and Footer Message, include a CSS URL that can be used to style the Bonobo instance without needing to modify the inbuilt stylesheet, which can be easily overwritten during an upgrade.
