### PR TITLE
Store the actual domain username in the user model

### DIFF
--- a/Bonobo.Git.Server/Data/ADBackend.cs
+++ b/Bonobo.Git.Server/Data/ADBackend.cs
@@ -129,7 +129,7 @@ namespace Bonobo.Git.Server.Data
                     result = new UserModel
                     {
                         Id = user.Guid.Value,
-                        Username = user.UserPrincipalName,
+                        Username = user.SamAccountName + "@" + user.Context.Name,
                         GivenName = user.GivenName ?? String.Empty,
                         Surname = user.Surname ?? String.Empty,
                         Email = user.EmailAddress ?? String.Empty,
@@ -170,15 +170,12 @@ namespace Bonobo.Git.Server.Data
                     {
                         Users.Remove(Id);
                     }
-                    foreach (string username in group.GetMembers(true).OfType<UserPrincipal>().Select(x => x.UserPrincipalName).Where(x => x != null))
+                    foreach (UserPrincipal principal in group.GetMembers(true).OfType<UserPrincipal>())
                     {
-                        using (var principal = ADHelper.GetUserPrincipal(username))
+                        UserModel user = GetUserModelFromPrincipal(principal);
+                        if (user != null)
                         {
-                            UserModel user = GetUserModelFromPrincipal(principal);
-                            if (user != null)
-                            {
-                                Users.AddOrUpdate(user);
-                            }
+                            Users.AddOrUpdate(user);
                         }
                     }
                 }
@@ -232,7 +229,7 @@ namespace Bonobo.Git.Server.Data
             {
                 Roles.Remove(role.Id);
             }
-            
+
             foreach (string roleName in ActiveDirectorySettings.RoleNameToGroupNameMapping.Keys)
             {
                 string groupName = ActiveDirectorySettings.RoleNameToGroupNameMapping[roleName];


### PR DESCRIPTION
This change includes 2 things:
- in UpdateUsers(), the previous code converted UserPrincipal objects into username strings, then back into UserPrincipal objects ... losing the original UserPrincipal.Context on the way, and with that any way to determine the actual user domain.
- the UserPrincipal.UserPrincipalName property does not always contain the correct domain name after the @ character (e.g. in environments where an internal "company.local" domain was connected with Office 365, and all users received the external email address as their UPN. Using the SamAccountName and user.Context.Name instead fixes this.