### PR TITLE
Fix for #838: Old year in footer section

### DIFF
--- a/Bonobo.Git.Server/Views/Shared/_Layout.cshtml
+++ b/Bonobo.Git.Server/Views/Shared/_Layout.cshtml
@@ -69,7 +69,7 @@
                     @UserConfiguration.Current.SiteFooterMessage
                     @:&middot;
                 }
-                Bonobo Git Server (@Html.AssemblyVersion()) &copy; 2015 <a href="http://www.chodounsky.net">Jakub Chodounský</a>
+                Bonobo Git Server (@Html.AssemblyVersion()) &copy; 2019 <a href="http://www.chodounsky.net">Jakub Chodounský</a>
                 &middot; <a href="http://bonobogitserver.com/">@Resources.Home</a> 
                 &middot; <a href="https://github.com/jakubgarfield/Bonobo-Git-Server">@Resources.Source</a>
             </p>


### PR DESCRIPTION
2019 is the current year now.