### PR TITLE
Add AD Caching - Fixes #872

### DIFF
--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -284,6 +284,7 @@
     <Compile Include="Controllers\ValidationController.cs" />
     <Compile Include="Data\ADBackend.cs" />
     <Compile Include="Data\ADBackendStore.cs" />
+    <Compile Include="Data\ADCachedPrincipal.cs" />
     <Compile Include="Data\ADRepositoryRepository.cs" />
     <Compile Include="Data\ADTeamRepository.cs" />
     <Compile Include="Data\DatabaseResetManager.cs" />

--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -320,6 +320,7 @@
     <Compile Include="Git\GitService\ReceivePackHook\ReceivePackCommitSignature.cs" />
     <Compile Include="Git\GitService\ReplicatingStream.cs" />
     <Compile Include="Helpers\ADHelper.cs" />
+    <Compile Include="Helpers\ConfigurationHelper.cs" />
     <Compile Include="Helpers\MembershipHelper.cs" />
     <Compile Include="Helpers\RepositoryCommitModelHelpers.cs" />
     <Compile Include="Models\RepositoryCommitTitle.cs" />

--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -285,6 +285,7 @@
     <Compile Include="Data\ADBackend.cs" />
     <Compile Include="Data\ADBackendStore.cs" />
     <Compile Include="Data\ADCachedPrincipal.cs" />
+    <Compile Include="Data\ADCachedSearchResult.cs" />
     <Compile Include="Data\ADRepositoryRepository.cs" />
     <Compile Include="Data\ADTeamRepository.cs" />
     <Compile Include="Data\DatabaseResetManager.cs" />

--- a/Bonobo.Git.Server/Data/ADBackend.cs
+++ b/Bonobo.Git.Server/Data/ADBackend.cs
@@ -171,7 +171,7 @@ namespace Bonobo.Git.Server.Data
                     Users.Remove(Id);
                 }
 
-                foreach (string username in group.GetMembers(true).OfType<UserPrincipal>().Select(x => x.UserPrincipalName).Where(x => x != null))
+                foreach (string username in ADHelper.GetGroupMembers(group).OfType<UserPrincipal>().Select(x => x.UserPrincipalName).Where(x => x != null))
                 {
                     UserPrincipal principal = ADHelper.GetUserPrincipal(username);
                     UserModel user = GetUserModelFromPrincipal(principal);
@@ -211,7 +211,7 @@ namespace Bonobo.Git.Server.Data
                         Id = group.Guid.Value,
                         Description = group.Description,
                         Name = teamName,
-                        Members = group.GetMembers(true).Select(x => MembershipService.GetUserModel(x.Guid.Value)).Where(o => o != null).ToArray()
+                        Members = ADHelper.GetGroupMembers(group).Select(x => MembershipService.GetUserModel(x.Guid.Value)).Where(o => o != null).ToArray()
                     };
                     Teams.AddOrUpdate(teamModel);
                     Log.Verbose("AD: Updated team {TeamName} OK", teamName);
@@ -242,7 +242,7 @@ namespace Bonobo.Git.Server.Data
                     {
                         Id = group.Guid.Value,
                         Name = roleName,
-                        Members = group.GetMembers(true).Where(x => x is UserPrincipal).Select(x => x.Guid.Value)
+                        Members = ADHelper.GetGroupMembers(group).Where(x => x is UserPrincipal).Select(x => x.Guid.Value)
                                 .ToArray()
                     };
                     Roles.AddOrUpdate(roleModel);

--- a/Bonobo.Git.Server/Data/ADCachedPrincipal.cs
+++ b/Bonobo.Git.Server/Data/ADCachedPrincipal.cs
@@ -13,13 +13,13 @@ namespace Bonobo.Git.Server.Data
         public PrincipalContext PrincipalContext { get; private set; }
 
 
-        private bool Disposing;
+        private bool _Disposing;
 
 
         public ADCachedPrincipal(PrincipalContext pc, Principal principal)
         {
+            _Disposing = false;
             CacheTime = DateTime.UtcNow;
-            Disposing = false;
             Principal = principal;
             PrincipalContext = pc;
         }
@@ -27,12 +27,12 @@ namespace Bonobo.Git.Server.Data
 
         public void Dispose()
         {
-            if (Disposing)
+            if (_Disposing)
             {
-                throw new ObjectDisposedException("Principal");
+                throw new ObjectDisposedException(nameof(Principal));
             }
 
-            Disposing = true;
+            _Disposing = true;
             Principal.Dispose();
         }
     }

--- a/Bonobo.Git.Server/Data/ADCachedPrincipal.cs
+++ b/Bonobo.Git.Server/Data/ADCachedPrincipal.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.DirectoryServices.AccountManagement;
+using System.Linq;
+using System.Web;
+
+namespace Bonobo.Git.Server.Data
+{
+    public class ADCachedPrincipal
+    {
+        public DateTime CacheTime { get; private set; }
+        public Principal Principal { get; private set; }
+        public PrincipalContext PrincipalContext { get; private set; }
+
+
+        public ADCachedPrincipal(PrincipalContext pc, Principal principal)
+        {
+            CacheTime = DateTime.UtcNow;
+            Principal = principal;
+            PrincipalContext = pc;
+        }
+    }
+}

--- a/Bonobo.Git.Server/Data/ADCachedPrincipal.cs
+++ b/Bonobo.Git.Server/Data/ADCachedPrincipal.cs
@@ -13,12 +13,12 @@ namespace Bonobo.Git.Server.Data
         public PrincipalContext PrincipalContext { get; private set; }
 
 
-        private bool _Disposing;
+        private bool _disposing;
 
 
         public ADCachedPrincipal(PrincipalContext pc, Principal principal)
         {
-            _Disposing = false;
+            _disposing = false;
             CacheTime = DateTime.UtcNow;
             Principal = principal;
             PrincipalContext = pc;
@@ -27,12 +27,12 @@ namespace Bonobo.Git.Server.Data
 
         public void Dispose()
         {
-            if (_Disposing)
+            if (_disposing)
             {
-                throw new ObjectDisposedException(nameof(Principal));
+                throw new ObjectDisposedException(nameof(ADCachedPrincipal));
             }
 
-            _Disposing = true;
+            _disposing = true;
             Principal.Dispose();
         }
     }

--- a/Bonobo.Git.Server/Data/ADCachedPrincipal.cs
+++ b/Bonobo.Git.Server/Data/ADCachedPrincipal.cs
@@ -6,18 +6,34 @@ using System.Web;
 
 namespace Bonobo.Git.Server.Data
 {
-    public class ADCachedPrincipal
+    public class ADCachedPrincipal : IDisposable
     {
         public DateTime CacheTime { get; private set; }
         public Principal Principal { get; private set; }
         public PrincipalContext PrincipalContext { get; private set; }
 
 
+        private bool Disposing;
+
+
         public ADCachedPrincipal(PrincipalContext pc, Principal principal)
         {
             CacheTime = DateTime.UtcNow;
+            Disposing = false;
             Principal = principal;
             PrincipalContext = pc;
+        }
+
+
+        public void Dispose()
+        {
+            if (Disposing)
+            {
+                throw new ObjectDisposedException("Principal");
+            }
+
+            Disposing = true;
+            Principal.Dispose();
         }
     }
 }

--- a/Bonobo.Git.Server/Data/ADCachedSearchResult.cs
+++ b/Bonobo.Git.Server/Data/ADCachedSearchResult.cs
@@ -13,13 +13,13 @@ namespace Bonobo.Git.Server.Data
         public PrincipalSearchResult<Principal> SearchResults { get; private set; }
 
 
-        private bool Disposing;
+        private bool _Disposing;
 
 
         public ADCachedSearchResult(PrincipalSearchResult<Principal> searchResults)
         {
+            _Disposing = false;
             CacheTime = DateTime.UtcNow;
-            Disposing = false;
             SearchResults = searchResults;
 
             // Search results are lazy loaded, we should enum them now so the cache is
@@ -38,12 +38,12 @@ namespace Bonobo.Git.Server.Data
 
         public void Dispose()
         {
-            if (Disposing)
+            if (_Disposing)
             {
-                throw new ObjectDisposedException("SearchResults");
+                throw new ObjectDisposedException(nameof(SearchResults));
             }
 
-            Disposing = true;
+            _Disposing = true;
 
             foreach (Principal principal in Principals)
             {

--- a/Bonobo.Git.Server/Data/ADCachedSearchResult.cs
+++ b/Bonobo.Git.Server/Data/ADCachedSearchResult.cs
@@ -6,16 +6,20 @@ using System.Web;
 
 namespace Bonobo.Git.Server.Data
 {
-    public class ADCachedSearchResult
+    public class ADCachedSearchResult : IDisposable
     {
         public DateTime CacheTime { get; private set; }
         public IList<Principal> Principals { get; private set; }
         public PrincipalSearchResult<Principal> SearchResults { get; private set; }
 
 
+        private bool Disposing;
+
+
         public ADCachedSearchResult(PrincipalSearchResult<Principal> searchResults)
         {
             CacheTime = DateTime.UtcNow;
+            Disposing = false;
             SearchResults = searchResults;
 
             // Search results are lazy loaded, we should enum them now so the cache is
@@ -29,6 +33,24 @@ namespace Bonobo.Git.Server.Data
             }
 
             Principals = principals.AsReadOnly();
+        }
+
+
+        public void Dispose()
+        {
+            if (Disposing)
+            {
+                throw new ObjectDisposedException("SearchResults");
+            }
+
+            Disposing = true;
+
+            foreach (Principal principal in Principals)
+            {
+                principal.Dispose();
+            }
+
+            SearchResults.Dispose();
         }
     }
 }

--- a/Bonobo.Git.Server/Data/ADCachedSearchResult.cs
+++ b/Bonobo.Git.Server/Data/ADCachedSearchResult.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.DirectoryServices.AccountManagement;
+using System.Linq;
+using System.Web;
+
+namespace Bonobo.Git.Server.Data
+{
+    public class ADCachedSearchResult
+    {
+        public DateTime CacheTime { get; private set; }
+        public IList<Principal> Principals { get; private set; }
+        public PrincipalSearchResult<Principal> SearchResults { get; private set; }
+
+
+        public ADCachedSearchResult(PrincipalSearchResult<Principal> searchResults)
+        {
+            CacheTime = DateTime.UtcNow;
+            SearchResults = searchResults;
+
+            // Search results are lazy loaded, we should enum them now so the cache is
+            // effective
+            //
+            var principals = new List<Principal>();
+
+            foreach (Principal principal in SearchResults)
+            {
+                principals.Add(principal);
+            }
+
+            Principals = principals.AsReadOnly();
+        }
+    }
+}

--- a/Bonobo.Git.Server/Data/ADCachedSearchResult.cs
+++ b/Bonobo.Git.Server/Data/ADCachedSearchResult.cs
@@ -13,12 +13,12 @@ namespace Bonobo.Git.Server.Data
         public PrincipalSearchResult<Principal> SearchResults { get; private set; }
 
 
-        private bool _Disposing;
+        private bool _disposing;
 
 
         public ADCachedSearchResult(PrincipalSearchResult<Principal> searchResults)
         {
-            _Disposing = false;
+            _disposing = false;
             CacheTime = DateTime.UtcNow;
             SearchResults = searchResults;
 
@@ -38,12 +38,12 @@ namespace Bonobo.Git.Server.Data
 
         public void Dispose()
         {
-            if (_Disposing)
+            if (_disposing)
             {
-                throw new ObjectDisposedException(nameof(SearchResults));
+                throw new ObjectDisposedException(nameof(ADCachedSearchResult));
             }
 
-            _Disposing = true;
+            _disposing = true;
 
             foreach (Principal principal in Principals)
             {

--- a/Bonobo.Git.Server/Data/Update/ADBackend/UpdateADBackend.cs
+++ b/Bonobo.Git.Server/Data/Update/ADBackend/UpdateADBackend.cs
@@ -202,10 +202,9 @@ namespace Bonobo.Git.Server.Data.Update.ADBackendUpdate
                 try
                 {
                     GroupPrincipal group;
-                    using (var pc = ADHelper.GetPrincipalGroup(ActiveDirectorySettings.TeamNameToGroupNameMapping[team.Name], out group))
-                    {
-                        newteam.Id = group.Guid.Value;
-                    }
+                    PrincipalContext pc = ADHelper.GetPrincipalGroup(ActiveDirectorySettings.TeamNameToGroupNameMapping[team.Name], out group);
+
+                    newteam.Id = group.Guid.Value;
                 }
                 catch (Exception ex)
                 {

--- a/Bonobo.Git.Server/Helpers/ADHelper.cs
+++ b/Bonobo.Git.Server/Helpers/ADHelper.cs
@@ -1,15 +1,24 @@
 ﻿using Bonobo.Git.Server.Configuration;
+using Bonobo.Git.Server.Data;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.DirectoryServices.AccountManagement;
 using System.DirectoryServices.ActiveDirectory;
 using Serilog;
+using System.Security.Principal;
 
 namespace Bonobo.Git.Server.Helpers
 {
     public static class ADHelper
     {
+        private static Dictionary<string, PrincipalContext> CachedPrincipalContexts = new Dictionary<string, PrincipalContext>();
+        private static object CachedPrincipalContextsLock = new object();
+
+        private static List<ADCachedPrincipal> CachedPrincipals = new List<ADCachedPrincipal>();
+        private static object CachedPrincipalsLock = new object();
+
+
         /// <summary>
         /// There are various sources of domains which we need to check
         /// Try to lazy-enumerate this, so that expensive functions aren't called if they're not necessary
@@ -114,15 +123,14 @@ namespace Bonobo.Git.Server.Helpers
             {
                 Log.Information("AD: Validating {UserName} in domain {DomainName}", username, domain.Name);
 
-                using (PrincipalContext pc = new PrincipalContext(ContextType.Domain, domain.Name))
+                PrincipalContext pc = GetPrincipalContext(ContextType.Domain, domain.Name);
+
+                if (pc.ValidateCredentials(username, password, ContextOptions.Negotiate))
                 {
-                    if (pc.ValidateCredentials(username, password, ContextOptions.Negotiate))
-                    {
-                        Log.Information("AD: Success validating {UserName} in domain {DomainName}", username, domain.Name);
-                        return true;
-                    }
-                    Log.Warning("AD: Validating {UserName} in domain {DomainName} failed", username, domain.Name);
+                    Log.Information("AD: Success validating {UserName} in domain {DomainName}", username, domain.Name);
+                    return true;
                 }
+                Log.Warning("AD: Validating {UserName} in domain {DomainName} failed", username, domain.Name);
             }
             catch (Exception exp)
             {
@@ -141,7 +149,7 @@ namespace Bonobo.Git.Server.Helpers
             { 
 
                 var dc = new DirectoryContext(DirectoryContextType.Domain, parsedDomainName);
-
+                
                 domain = Domain.GetDomain(dc);
             }
             catch (Exception exp)
@@ -163,6 +171,11 @@ namespace Bonobo.Git.Server.Helpers
 
             Log.Verbose("GetUserPrincipal: username {UserName}, domain {DomainName}, stripped {StrippedUserName}", username, parsedDomainName, strippedUsername);
 
+            var cachedUserData = GetCachedPrincipalData(username);
+
+            if (cachedUserData != null)
+                return cachedUserData.Principal as UserPrincipal;
+
             foreach (var domain in GetAllDomainPossibilities(username))
             {
                 var user = GetUserPrincipal(domain, username, strippedUsername);
@@ -177,27 +190,38 @@ namespace Bonobo.Git.Server.Helpers
 
         private static UserPrincipal GetUserPrincipal(Domain domain, string fullUsername, string strippedUsername)
         {
+            var attempts = new string[] { fullUsername, strippedUsername };
+
+            foreach (string name in attempts)
+            {
+                var cachedUser = GetCachedPrincipalData(name);
+
+                if (cachedUser != null)
+                    return cachedUser.Principal as UserPrincipal;
+            }
+
             try
             {
-                using (var pc = new PrincipalContext(ContextType.Domain, domain.Name))
+                PrincipalContext pc = GetPrincipalContext(ContextType.Domain, domain.Name);
+
+                UserPrincipal principalBySamName = UserPrincipal.FindByIdentity(pc, IdentityType.SamAccountName, strippedUsername);
+                if (principalBySamName != null)
                 {
-                    UserPrincipal principalBySamName = UserPrincipal.FindByIdentity(pc, IdentityType.SamAccountName, strippedUsername);
-                    if (principalBySamName != null)
-                    {
-                        return principalBySamName;
-                    }
-
-                    Log.Verbose("GetUserPrincipal: Did not find user {UserName} in domain {DomainName} by SamAccountName", strippedUsername, domain.Name);
-
-                    UserPrincipal principalByUPN = UserPrincipal.FindByIdentity(pc, IdentityType.UserPrincipalName, fullUsername);
-                    if (principalByUPN == null)
-                    {
-                        Log.Verbose(
-                            "GetUserPrincipal: Did not find user {UserName} in domain {DomainName} by UPN",
-                            fullUsername, domain.Name);
-                    }
-                    return principalByUPN;
+                    CachedPrincipals.Add(new ADCachedPrincipal(pc, principalBySamName));
+                    return principalBySamName;
                 }
+
+                Log.Verbose("GetUserPrincipal: Did not find user {UserName} in domain {DomainName} by SamAccountName", strippedUsername, domain.Name);
+
+                UserPrincipal principalByUPN = UserPrincipal.FindByIdentity(pc, IdentityType.UserPrincipalName, fullUsername);
+                if (principalByUPN == null)
+                {
+                    Log.Verbose(
+                        "GetUserPrincipal: Did not find user {UserName} in domain {DomainName} by UPN",
+                        fullUsername, domain.Name);
+                }
+                CachedPrincipals.Add(new ADCachedPrincipal(pc, principalByUPN));
+                return principalByUPN;
             }
             catch (Exception exp)
             {
@@ -212,17 +236,24 @@ namespace Bonobo.Git.Server.Helpers
         /// <returns>The Userprincipal if found, else null</returns>
         public static UserPrincipal GetUserPrincipal(Guid id)
         {
+            var cachedUser = GetCachedPrincipalData(id);
+
+            if (cachedUser != null)
+                return cachedUser.Principal as UserPrincipal;
+
             foreach (Domain domain in GetAllDomainPossibilities())
             {
                 try
                 {
-                    using (var pc = new PrincipalContext(ContextType.Domain, domain.Name))
-                    {
-                        Log.Information("Looking for user with guid {guid} in domain {domain}", id.ToString(), domain.Name);
+                    PrincipalContext pc = GetPrincipalContext(ContextType.Domain, domain.Name);
 
-                        var user = UserPrincipal.FindByIdentity(pc, IdentityType.Guid, id.ToString());
-                        if (user != null)
-                            return user;
+                    Log.Information("Looking for user with guid {guid} in domain {domain}", id.ToString(), domain.Name);
+
+                    var user = UserPrincipal.FindByIdentity(pc, IdentityType.Guid, id.ToString());
+                    if (user != null)
+                    {
+                        CachedPrincipals.Add(new ADCachedPrincipal(pc, user));
+                        return user;
                     }
                 }
                 catch (Exception exp)
@@ -255,6 +286,14 @@ namespace Bonobo.Git.Server.Helpers
         /// <returns>Principal context on which the group was found.</returns>
         public static PrincipalContext GetPrincipalGroup(string name, out GroupPrincipal group)
         {
+            var cachedGroupData = GetCachedPrincipalData(name);
+
+            if (cachedGroupData != null)
+            {
+                group = cachedGroupData.Principal as GroupPrincipal;
+                return cachedGroupData.PrincipalContext;
+            }
+
             foreach (Domain domain in GetAllDomainPossibilities())
             {
                 Log.Information("Searching for group {name} in domain {domain}", name, domain.Name);
@@ -264,7 +303,10 @@ namespace Bonobo.Git.Server.Helpers
                     var pc = new PrincipalContext(ContextType.Domain, domain.Name);
                     group = GroupPrincipal.FindByIdentity(pc, IdentityType.Name, name);
                     if (group != null)
+                    {
+                        CachedPrincipals.Add(new ADCachedPrincipal(pc, group));
                         return pc;
+                    }
                 }
                 catch (Exception exp)
                 {
@@ -273,6 +315,105 @@ namespace Bonobo.Git.Server.Helpers
                 }
             }
             throw new ArgumentException("Could not find principal group: " + name);
+        }
+
+
+        private static PrincipalContext GetPrincipalContext(ContextType contextType, string name)
+        {
+            string safeName = name.ToLower();
+
+            lock (CachedPrincipalContextsLock)
+            {
+                if (CachedPrincipalContexts.ContainsKey(safeName))
+                {
+                    Log.Verbose("ADCACHE: Cache hit for context {Domain}", name);
+                    return CachedPrincipalContexts[safeName];
+                }
+
+                Log.Verbose("ADCACHE: Cache miss for context {Domain}", name);
+
+                var pc = new PrincipalContext(contextType, name);
+
+                CachedPrincipalContexts.Add(safeName, pc);
+
+                return pc;
+            }
+        }
+
+        private static ADCachedPrincipal GetCachedPrincipalData(Guid guid)
+        {
+            TimeSpan tenMinutes = new TimeSpan(0, 10, 0);
+
+            lock (CachedPrincipalsLock)
+            {
+                for (int i = CachedPrincipals.Count - 1; i >= 0; i--)
+                {
+                    ADCachedPrincipal dataSet = CachedPrincipals[i];
+
+                    if (DateTime.UtcNow.Subtract(tenMinutes) > dataSet.CacheTime)
+                    {
+                        Log.Verbose("ADCACHE: Cache expired for {Guid}", guid);
+
+                        dataSet.Principal.Dispose();
+                        CachedPrincipals.RemoveAt(i);
+                        continue;
+                    }
+
+                    if (dataSet.Principal.Guid == guid)
+                    {
+                        Log.Verbose("ADCACHE: Cache hit for {Guid}", guid);
+                        return dataSet;
+                    }
+                }
+            }
+
+            Log.Verbose("ADCACHE: Cache miss for {Guid}", guid);
+
+            return null;
+        }
+
+        private static ADCachedPrincipal GetCachedPrincipalData(string name)
+        {
+            TimeSpan tenMinutes = new TimeSpan(0, 10, 0);
+            bool     searchUpn  = name.Contains("@");
+
+            lock (CachedPrincipalsLock)
+            {
+                for (int i = CachedPrincipals.Count - 1; i >= 0; i--)
+                {
+                    ADCachedPrincipal dataSet = CachedPrincipals[i];
+
+                    if (DateTime.UtcNow.Subtract(tenMinutes) > dataSet.CacheTime)
+                    {
+                        Log.Verbose("ADCACHE: Cache expired for {Name}", name);
+
+                        dataSet.Principal.Dispose();
+                        CachedPrincipals.RemoveAt(i);
+                        continue;
+                    }
+
+                    if (searchUpn && !string.IsNullOrEmpty(dataSet.Principal.UserPrincipalName))
+                    {
+                        if (dataSet.Principal.UserPrincipalName.Equals(name, StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            Log.Verbose("ADCACHE: Cache hit for {UPN}", name);
+                            return dataSet;
+                        }
+                    }
+                    else
+                    {
+                        if (dataSet.Principal.SamAccountName.Equals(name, StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            Log.Verbose("ADCACHE: Cache hit for {SamAccountName}", name);
+                            return dataSet;
+                        }
+                    }
+                }
+            }
+
+            Log.Verbose("ADCACHE: Cache miss for {Name}", name);
+
+            return null;
         }
     }
 }

--- a/Bonobo.Git.Server/Helpers/ConfigurationHelper.cs
+++ b/Bonobo.Git.Server/Helpers/ConfigurationHelper.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Bonobo.Git.Server.Helpers
+{
+    public static class ConfigurationHelper
+    {
+        public static TimeSpan ParseTimeSpanOrDefault(string value, TimeSpan otherwise)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return otherwise;
+            }
+
+            TimeSpan res;
+
+            if (TimeSpan.TryParse(value, out res))
+            {
+                return res;
+            }
+
+            return otherwise;
+        }
+    }
+}

--- a/Bonobo.Git.Server/Security/ADMembershipService.cs
+++ b/Bonobo.Git.Server/Security/ADMembershipService.cs
@@ -37,26 +37,23 @@ namespace Bonobo.Git.Server.Security
             {
                 if (ADHelper.ValidateUser(username, password))
                 {
-                    using (var user = ADHelper.GetUserPrincipal(username))
-                    {
-                        GroupPrincipal group;
-						using (var pc = ADHelper.GetMembersGroup(out group))
-						{
-							if (group == null)
-								result = ValidationResult.Failure;
+                    UserPrincipal user = ADHelper.GetUserPrincipal(username);
+                    GroupPrincipal group;
+                    PrincipalContext pc = ADHelper.GetMembersGroup(out group);
 
-							if (user != null)
-							{
-								if (!group.GetMembers(true).Contains(user))
-								{
-									result = ValidationResult.NotAuthorized;
-								}
-								else
-								{
-									result = ValidationResult.Success;
-								}
-							}
-						}
+                    if (group == null)
+                        result = ValidationResult.Failure;
+
+                    if (user != null)
+                    {
+                        if (!group.GetMembers(true).Contains(user))
+                        {
+                            result = ValidationResult.NotAuthorized;
+                        }
+                        else
+                        {
+                            result = ValidationResult.Success;
+                        }
                     }
                 }
             }
@@ -87,10 +84,10 @@ namespace Bonobo.Git.Server.Security
 
         public UserModel GetUserModel(string username)
         {
-            using (var upc = ADHelper.GetUserPrincipal(username))
-            {
-                return ADBackend.Instance.Users.FirstOrDefault(n => n.Id == upc.Guid.Value);
-            }
+            UserPrincipal upc = ADHelper.GetUserPrincipal(username);
+
+            return ADBackend.Instance.Users.FirstOrDefault(n => n.Id == upc.Guid.Value);
+
             throw new ArgumentException("User was not found with username: " + username);
         }
 

--- a/Bonobo.Git.Server/Security/ADMembershipService.cs
+++ b/Bonobo.Git.Server/Security/ADMembershipService.cs
@@ -46,7 +46,7 @@ namespace Bonobo.Git.Server.Security
 
                     if (user != null)
                     {
-                        if (!group.GetMembers(true).Contains(user))
+                        if (!ADHelper.GetGroupMembers(group).Contains(user))
                         {
                             result = ValidationResult.NotAuthorized;
                         }


### PR DESCRIPTION
This PR introduces support for caching AD contexts, principals, and group member queries.

Two config keys are added:
`ActiveDirectoryGroupQueryCacheExpiry` - the cached results of group member enumerations will be considered stale after this amount of time
`ActiveDirectoryPrincipalCacheExpiry` - the cached `GroupPrincipal` and `UserPrincipal` objects will be considered stale after this amount of time

Fixes #872