### PR TITLE
Add 50 tests for controllers

### DIFF
--- a/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
+++ b/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
@@ -50,7 +50,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\packages\Castle.Core.4.4.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
@@ -69,6 +69,7 @@
     <Reference Include="Moq, Version=4.15.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.15.2\lib\net45\Moq.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
@@ -170,13 +171,20 @@
     <Compile Include="Unit\DatabaseUpdateTestsSqlite.cs" />
     <Compile Include="Unit\DatabaseUpdateTestsSqlServer.cs" />
     <Compile Include="Unit\PathEncoderTest.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TestCategories.cs" />
     <Compile Include="Unit\PasswordServiceTest.cs" />
     <Compile Include="Unit\GitAuthorizeAttributeTest.cs" />
+    <Compile Include="Unit\ControllerDependendencyBuilders.cs" />
     <Compile Include="Unit\UserConfigurationTests.cs" />
     <Compile Include="Unit\UserExtensionsTests.cs" />
     <Compile Include="Unit\UserModelTest.cs" />
+    <Compile Include="Unit\ControllerTests.cs" />
+    <Compile Include="Unit\ControllerTests.AccountControllerTests.cs" />
+    <Compile Include="Unit\ControllerTests.HomeControllerTests.cs" />
+    <Compile Include="Unit\ControllerTests.SettingsControllerTests.cs" />
+    <Compile Include="Unit\ControllerTests.TeamControllerTests.cs" />
+    <Compile Include="Unit\ControllerTests.RepositoryControllerTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestCategories.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bonobo.Git.Server\Bonobo.Git.Server.csproj">

--- a/Bonobo.Git.Server.Test/Unit/ControllerDependendencyBuilders.cs
+++ b/Bonobo.Git.Server.Test/Unit/ControllerDependendencyBuilders.cs
@@ -1,0 +1,73 @@
+﻿using Bonobo.Git.Server.Data;
+using Bonobo.Git.Server.Models;
+using Bonobo.Git.Server.Security;
+using Moq;
+using System;
+using System.Collections.Generic;
+
+namespace Bonobo.Git.Server.Test.Unit
+{
+    public static class ControllerDependendencyBuilders
+    {
+        // TeamRepository Mock
+        public static Mock<ITeamRepository> SetupToSucceedWhenCreatingATeam(this Mock<ITeamRepository> teamRepositoryMock)
+        {
+            teamRepositoryMock.Setup(r => r.Create(It.IsAny<TeamModel>()))
+                              .Returns(true);
+            return teamRepositoryMock;
+        }
+
+        public static Mock<ITeamRepository> SetupToReturnASpecificTeamWhenCallingGetTeamMethod(this Mock<ITeamRepository> teamRepositoryMock, Guid requestedGuid)
+        {
+            teamRepositoryMock.Setup(t => t.GetTeam(requestedGuid))
+                              .Returns(new TeamModel
+                              {
+                                  Id = requestedGuid,
+                                  Members = new UserModel[0]
+                              });
+            return teamRepositoryMock;
+        }
+
+        // MembershipService Mock
+        public static Mock<IMembershipService> SetupToReturnAnEmptyUserModelListWhenCallingGetAllUsers(this Mock<IMembershipService> membershipServiceMock)
+        {
+            membershipServiceMock.Setup(m => m.GetAllUsers())
+                                 .Returns(new List<UserModel>());
+            return membershipServiceMock;
+        }
+
+        public static Mock<IMembershipService> SetupToReturnARequestedUserModel(this Mock<IMembershipService> membershipServiceMock, string requestedUserName)
+        {
+            membershipServiceMock.Setup(m => m.GetUserModel(requestedUserName))
+                                 .Returns(new UserModel { Username = requestedUserName });
+            return membershipServiceMock;
+        }
+
+        public static Mock<IMembershipService> SetupToGenerateResetToken(this Mock<IMembershipService> membershipServiceMock, string token, string requestedUserName)
+        {
+            membershipServiceMock.Setup(m => m.GenerateResetToken(requestedUserName))
+                                 .Returns(token);
+            return membershipServiceMock;
+        }
+
+        // IRepositoryRepository Mock
+        public static Mock<IRepositoryRepository> SetupToReturnAnEmptyListForASpecificIdWhenCallingGetTeamRepositories(this Mock<IRepositoryRepository> repositoryRepositoryMock, Guid requestedId)
+        {
+            repositoryRepositoryMock.Setup(r => r.GetTeamRepositories(new[] { requestedId }))
+                                    .Returns(new List<RepositoryModel>());
+            return repositoryRepositoryMock;
+        }
+
+        public static Mock<IRepositoryRepository> SetupToReturnAModelWithASpecificIdWhenCallingGetRepositoryMethod(this Mock<IRepositoryRepository> repositoryRepositoryMock, Guid guid)
+        {
+            repositoryRepositoryMock.Setup(s => s.GetRepository(guid))
+                                    .Returns(new RepositoryModel
+                                    {
+                                        Id = guid,
+                                        Administrators = new UserModel[0],
+                                        Name = "name"
+                                    });
+            return repositoryRepositoryMock;
+        }
+    }
+}

--- a/Bonobo.Git.Server.Test/Unit/ControllerTests.AccountControllerTests.cs
+++ b/Bonobo.Git.Server.Test/Unit/ControllerTests.AccountControllerTests.cs
@@ -1,0 +1,363 @@
+using Bonobo.Git.Server.App_GlobalResources;
+using Bonobo.Git.Server.Configuration;
+using Bonobo.Git.Server.Controllers;
+using Bonobo.Git.Server.Models;
+using Bonobo.Git.Server.Security;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Configuration;
+using System.Security.Principal;
+using System.Web.Mvc;
+
+namespace Bonobo.Git.Server.Test.Unit
+{
+    public partial class ControllerTests
+    {
+        [TestClass]
+        public class AccountControllerTests : ControllerTests
+        {
+            [TestInitialize]
+            public void TestInitialize()
+            {
+                sut = new AccountController();
+            }
+
+            // get Delete
+            // post Delete
+
+            [TestMethod]
+            public void Get_Edit_Executed_With_Null_Parameters__Throws_NullReferenceException()
+            {
+                try
+                {
+                    // arrange
+                    SetHttpContextMockIntoSUT(Guid.Empty);
+                    // act
+                    var result = SutAs<AccountController>().Edit(null);
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+                //assert
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Get_Edit_When_User_Is_Unknown_And_Resulting_Model_Is_Null__Stays_On_View()
+            {
+                // Arrange
+                Guid userid = Guid.NewGuid();
+                SetHttpContextMockIntoSUT(userid);
+                SetupMembershipServiceMockIntoSUT();
+                BindModelToController(userid);
+
+                // act
+                var result = SutAs<AccountController>().Edit(userid);
+
+                // assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(ViewResult));
+                var viewResult = result as ViewResult;
+                Assert.IsNotNull(viewResult);
+                Assert.IsNull(viewResult.Model);
+            }
+
+            [TestMethod]
+            public void Get_Edit_When_Non_Admin_User_Queries_Other_UserId__Gets_Redirected_To_Home_Unauthorized()
+            {
+                // Arrange
+                Guid userid = Guid.NewGuid();
+                SetHttpContextMockIntoSUT(userid);
+                BindModelToController(userid);
+
+                // act
+                var result = SutAs<AccountController>().Edit(Guid.NewGuid());
+
+                // assert
+                AssertRedirectToHomeUnauthorized(result);
+            }
+
+            [TestMethod]
+            public void Get_Edit_When_Admin_User_Queries_Other_User_Id_And_Resulting_Model_Is_Null__Stays_On_View()
+            {
+                // Arrange
+                Guid userid = Guid.NewGuid();
+                Guid otherId = Guid.NewGuid();
+                SetHttpContextMockIntoSUT(userid);
+                SetupMembershipServiceMockIntoSUT();
+                SetupUserAsAdmin();
+                BindModelToController(userid);
+
+                // act
+                var result = SutAs<AccountController>().Edit(otherId);
+                var viewResult = result as ViewResult;
+
+                // assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(ViewResult));
+                Assert.IsNotNull(viewResult);
+                Assert.IsNull(viewResult.Model);
+            }
+
+            [TestMethod]
+            public void Get_Edit_When_User_Is_Known_And_Resulting_Model_Is_Not_Null__Stays_On_View()
+            {
+                // Arrange
+                Guid userId = Guid.NewGuid();
+                SetHttpContextMockIntoSUT(userId);
+                SetupMembershipServiceMockIntoSUT();
+                BindModelToController(userId);
+                membershipServiceMock.Setup(m => m.GetUserModel(userId))
+                                     .Returns(new UserModel
+                                     {
+                                         Id = userId,
+                                         Username = "Username",
+                                         GivenName = "Given",
+                                         Surname = "Sur",
+                                         Email = "email"
+                                     });
+
+                string[] allRoles = new string[] { "role1", "role2" };
+                string[] selectedRoles = new string[] { "role1" };
+                SetupRolesProviderMockIntoSUT();
+                roleProviderMock.Setup(r => r.GetAllRoles())
+                                .Returns(allRoles);
+                roleProviderMock.Setup(r => r.GetRolesForUser(userId))
+                                .Returns(selectedRoles);
+
+                // act
+                var result = SutAs<AccountController>().Edit(userId);
+                var viewResult = result as ViewResult;
+                var userEditModel = viewResult?.Model as UserEditModel;
+
+                // assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(ViewResult));
+                Assert.IsNotNull(viewResult);
+                Assert.IsNotNull(viewResult.Model);
+                Assert.IsInstanceOfType(viewResult.Model, typeof(UserEditModel));
+                Assert.AreEqual(userEditModel.Id, userId);
+                Assert.AreEqual(userEditModel.Username, "Username");
+                Assert.AreEqual(userEditModel.Name, "Given");
+                Assert.AreEqual(userEditModel.Surname, "Sur");
+                Assert.AreEqual(userEditModel.Email, "email");
+                Assert.AreEqual(userEditModel.Roles, allRoles);
+                Assert.AreEqual(userEditModel.SelectedRoles, selectedRoles);
+            }
+
+            [TestMethod]
+            public void Post_Edit_With_Unbound_Empty_Model_And_Environment_Unprepared__Throws_A_NullReferenceException()
+            {
+                try
+                {
+                    SutAs<AccountController>().Edit(new UserEditModel());
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Post_Edit_With_Unbound_Bare_Model_Data_Referring_To_The_Same_User__Returns_Weird_Data()
+            {
+                // Arrange
+                Guid userId = Guid.NewGuid();
+                UserEditModel model = new UserEditModel { Id = userId };
+
+                SetupMinimalEnvironment(userId);
+
+                // act
+                var result = SutAs<AccountController>().Edit(model);
+
+                AssertMinimalViewResult(result, userId);
+                AssertSuccessfulResponse(result);
+            }
+
+            [TestMethod]
+            public void Post_Edit_With_Unbound_Bare_Model_And_Admin_And_DemoActive_Configuration_Set_And_Data_Referring_To_The_Same_UserId__Redirects_To_Home_Unauthorized()
+            {
+                // Arrange
+                ConfigurationManager.AppSettings["demoModeActive"] = "true";
+                // AuthenticationSettings class controller needs to run again because we changed the demoModelActive appSetting
+                ReinitializeStaticClass(typeof(AuthenticationSettings));
+
+                Guid userId = Guid.NewGuid();
+                SetupMinimalEnvironment(userId);
+                UserEditModel model = new UserEditModel { Id = userId };
+                SetupUserAsAdmin();
+
+                // Act
+                var result = SutAs<AccountController>().Edit(model);
+
+                // Assert
+                AssertRedirectToHomeUnauthorized(result);
+            }
+
+            [TestMethod]
+            public void Post_Edit_With_Bound_Empty_Model_And_Correct_Environment__Passes_Execution()
+            {
+                // Arrange
+                sut.ControllerContext = CreateControllerContext();
+                SetupMembershipServiceMockIntoSUT();
+                SetupRolesProviderMockIntoSUT();
+                UserEditModel model = new UserEditModel();
+                BindModelToController(model);
+
+                // Act
+                var result = SutAs<AccountController>().Edit(model);
+
+                // Assert
+                AssertMinimalViewResult(result, Guid.Empty);
+            }
+
+            [TestMethod]
+            public void Post_Edit_With_Bound_Bare_Model_Data_Referring_To_The_Same_User__Returns_Null_Update_Success_In_ViewBag()
+            {
+                // Arrange
+                Guid userId = Guid.NewGuid();
+                SetupMinimalEnvironment(userId);
+                UserEditModel model = new UserEditModel { Id = userId };
+                BindModelToController(model);
+
+                // act
+                var result = SutAs<AccountController>().Edit(model);
+
+                AssertMinimalViewResult(result, userId);
+                Assert.IsFalse(sut.ModelState.IsValid);
+                Assert.AreEqual(4, sut.ModelState.Count);
+                Assert.IsNull((result as ViewResult).ViewBag.UpdateSuccess);
+            }
+
+            [TestMethod]
+            public void Post_Edit_With_Bound_Bare_Model_Data_Referring_To_Another_User__Redirects_To_Home_Unauthorized()
+            {
+                // Arrange
+                Guid userId = Guid.NewGuid();
+                Guid otherId = Guid.NewGuid();
+                SetupMinimalEnvironment(userId);
+                UserEditModel model = new UserEditModel { Id = otherId };
+                BindModelToController(model);
+
+                // act
+                var result = SutAs<AccountController>().Edit(model);
+
+                // assert
+                Assert.IsNotNull(result);
+
+                AssertRedirectToHomeUnauthorized(result);
+            }
+
+            [TestMethod]
+            public void Post_Edit_With_Bound_Invalid_Model_With_NewPassword_Not_Empty_And_OldPassword_Empty__Returns_Expected_ModelState()
+            {
+                // Arrange
+                Guid userId = Guid.NewGuid();
+                SetupMinimalEnvironment(userId);
+                UserEditModel model = new UserEditModel
+                {
+                    Id = userId,
+                    Username = "Username",
+                    Name = "Name",
+                    Surname = "Surname",
+                    Email = "email@test.com",
+                    NewPassword = "NewPassword"
+                };
+                BindModelToController(model);
+
+                // Act
+                var result = SutAs<AccountController>().Edit(model);
+
+                // Assert
+                AssertMinimalViewResult(result, userId);
+                Assert.IsFalse(sut.ModelState.IsValid);
+
+                string expectedMessageForConfirmPassword = String.Format(Resources.Validation_Compare, "Confirm Password", "New Password");
+                string actualMessageForConfirmPassword = sut.ModelState["ConfirmPassword"].Errors[0].ErrorMessage;
+
+                Assert.AreEqual(expectedMessageForConfirmPassword, actualMessageForConfirmPassword);
+            }
+
+            [TestMethod]
+            public void Post_Edit_With_Bound_Valid_Model_Data_Referring_To_The_Same_User__Returns_Data_From_The_User()
+            {
+                // Arrange
+                Guid userId = Guid.NewGuid();
+                SetupMinimalEnvironment(userId);
+
+                UserEditModel model = new UserEditModel
+                {
+                    Id = userId,
+                    Username = "Username",
+                    Name = "Name",
+                    Surname = "Surname",
+                    Email = "email@test.com",
+                };
+                BindModelToController(model);
+
+                // act
+                var result = SutAs<AccountController>().Edit(model);
+
+                AssertMinimalViewResult(result, userId);
+                AssertSuccessfulResponse(result);
+            }
+
+            // get Create
+            // post Create
+
+            private void SetupMinimalEnvironment(Guid userId)
+            {
+                SetHttpContextMockIntoSUT(userId);
+                SetupMembershipServiceMockIntoSUT();
+                SetupRolesProviderMockIntoSUT();
+            }
+
+            private static void AssertMinimalViewResult(ActionResult result, Guid userId)
+            {
+                // assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(ViewResult));
+
+                var viewResult = result as ViewResult;
+
+                Assert.IsNotNull(viewResult);
+                Assert.IsNotNull(viewResult.Model);
+                Assert.IsInstanceOfType(viewResult.Model, typeof(UserEditModel));
+
+                var userEditModel = viewResult.Model as UserEditModel;
+
+                Assert.IsNotNull(userEditModel);
+                Assert.AreEqual(userId, userEditModel.Id);
+                Assert.IsNotNull(userEditModel.Roles);
+                Assert.IsNotNull(viewResult.ViewBag);
+            }
+
+            private void AssertSuccessfulResponse(ActionResult result)
+            {
+                Assert.IsTrue(sut.ModelState.IsValid);
+
+                ViewResult viewResult = result as ViewResult;
+
+                Assert.IsTrue(viewResult.ViewBag.UpdateSuccess);
+            }
+
+            private void SetupMembershipServiceMockIntoSUT()
+            {
+                membershipServiceMock = new Mock<IMembershipService>();
+                SutAs<AccountController>().MembershipService = membershipServiceMock.Object;
+            }
+
+            private void SetupRolesProviderMockIntoSUT()
+            {
+                roleProviderMock = new Mock<IRoleProvider>();
+                SutAs<AccountController>().RoleProvider = roleProviderMock.Object;
+            }
+
+            private Mock<IMembershipService> membershipServiceMock;
+            private Mock<IRoleProvider> roleProviderMock;
+        }
+    }
+}

--- a/Bonobo.Git.Server.Test/Unit/ControllerTests.HomeControllerTests.cs
+++ b/Bonobo.Git.Server.Test/Unit/ControllerTests.HomeControllerTests.cs
@@ -1,0 +1,200 @@
+﻿using Bonobo.Git.Server.App_GlobalResources;
+using Bonobo.Git.Server.Controllers;
+using Bonobo.Git.Server.Models;
+using Bonobo.Git.Server.Security;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Security.Principal;
+using System.Web;
+using System.Web.Mvc;
+
+namespace Bonobo.Git.Server.Test.Unit
+{
+    public partial class ControllerTests
+    {
+        [TestClass]
+        public class HomeControllerTests : ControllerTests
+        {
+            [TestInitialize]
+            public void TestInitialize()
+            {
+                sut = new HomeController();
+            }
+
+            [TestMethod]
+            public void Get_LogOn_Called_With_Null_Url__Throws_No_Exceptions()
+            {
+                // Arrange
+                string returnUrl = null;
+
+                // Act
+                var result = SutAs<HomeController>().LogOn(returnUrl);
+
+                // Assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(ViewResult));
+
+                var viewResult = result as ViewResult;
+
+                Assert.IsNotNull(viewResult.Model);
+                Assert.IsInstanceOfType(viewResult.Model, typeof(LogOnModel));
+
+                var logOnModel = viewResult.Model as LogOnModel;
+                Assert.IsNull(logOnModel.ReturnUrl);
+            }
+
+            [TestMethod]
+            public void Get_LogOn_Called_With_Non_Null_Url__Returns_ReturnUrl_In_Model()
+            {
+                // Arrange
+                const string returnUrl = "theurl";
+
+                // Act
+                var result = SutAs<HomeController>().LogOn(returnUrl);
+
+                // Assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(ViewResult));
+
+                var viewResult = result as ViewResult;
+
+                Assert.IsNotNull(viewResult.Model);
+                Assert.IsInstanceOfType(viewResult.Model, typeof(LogOnModel));
+
+                var logOnModel = viewResult.Model as LogOnModel;
+                Assert.AreEqual(returnUrl, logOnModel.ReturnUrl);
+            }
+
+            [TestMethod]
+            public void Post_Logon_Called_With_Null_Model__Throws_NullReferenceException()
+            {
+                // Arrange
+                LogOnModel model = null;
+
+                try
+                {
+                    // Act
+                    SutAs<HomeController>().LogOn(model);
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+
+                // Assert
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Post_Logon_Called_With_Empty_Model_And_Controller_Environment__Returns_ViewResult()
+            {
+                // Arrange
+                ArrangeBareContext();
+
+                membershipServiceMock.Setup(mp => mp.ValidateUser(It.IsAny<string>(), It.IsAny<string>()))
+                                     .Returns(ValidationResult.Failure);
+                LogOnModel model = new LogOnModel();
+
+                // Act
+                var result = SutAs<HomeController>().LogOn(model);
+
+                // Assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(ViewResult));
+            }
+
+            [TestMethod]
+            public void Post_Logon_Called_With_Bare_Model_Request_And_Good_Credentials__Returns_EmptyResult()
+            {
+                // Arrange
+                ArrangeBareContext();
+
+                const string username = "username";
+                const string password = "password";
+                membershipServiceMock.Setup(mp => mp.ValidateUser(username, password))
+                                     .Returns(ValidationResult.Success);
+                httpContextMock.SetupGet(hc => hc.Request)
+                               .Returns(new Mock<HttpRequestBase>().Object);
+                LogOnModel model = new LogOnModel { Username = username, Password = password };
+
+                // Act
+                var result = SutAs<HomeController>().LogOn(model);
+
+                // Assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(EmptyResult));
+            }
+
+            [TestMethod]
+            public void Post_Logon_Called_With_Bare_Model_And_No_Authorization__Returns_RedirectResult()
+            {
+                // Arrange
+                ArrangeBareContext();
+
+                const string username = "username";
+                const string password = "password";
+                membershipServiceMock.Setup(mp => mp.ValidateUser(username, password))
+                                     .Returns(ValidationResult.NotAuthorized);
+                httpContextMock.SetupGet(hc => hc.Request)
+                               .Returns(new Mock<HttpRequestBase>().Object);
+                LogOnModel model = new LogOnModel { Username = username, Password = password };
+
+                // Act
+                var result = SutAs<HomeController>().LogOn(model);
+
+                // Assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(RedirectResult));
+
+                var redirectResult = result as RedirectResult;
+                Assert.AreEqual("~/Home/Unauthorized", redirectResult.Url);
+            }
+
+            [TestMethod]
+            public void Post_Logon_Called_With_Bare_Model_And_Bad_Credentials__Returns_ViewResult()
+            {
+                // Arrange
+                ArrangeBareContext();
+
+                const string username = "username";
+                const string password = "password";
+                membershipServiceMock.Setup(mp => mp.ValidateUser(username, password))
+                                     .Returns(ValidationResult.Failure);
+                httpContextMock.SetupGet(hc => hc.Request)
+                               .Returns(new Mock<HttpRequestBase>().Object);
+                LogOnModel model = new LogOnModel { Username = username, Password = password };
+
+                // Act
+                var result = SutAs<HomeController>().LogOn(model);
+
+                // Assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(ViewResult));
+                Assert.IsFalse(sut.ModelState.IsValid);
+                Assert.AreEqual(Resources.Home_LogOn_UsernamePasswordIncorrect, sut.ModelState[""].Errors[0].ErrorMessage);
+            }
+
+            // get ResetPassword
+            // post ResetPassword
+            // get ForgotPassword
+            // post ForgotPassword
+
+            private void ArrangeBareContext()
+            {
+                sut.ControllerContext = CreateControllerContext();
+                SetupMembershipServiceMockIntoSUT();
+                SutAs<HomeController>().AuthenticationProvider = new Mock<IAuthenticationProvider>().Object;
+                SutAs<HomeController>().Url = new Mock<UrlHelper>().Object;
+            }
+
+            private void SetupMembershipServiceMockIntoSUT()
+            {
+                membershipServiceMock = new Mock<IMembershipService>();
+                SutAs<HomeController>().MembershipService = membershipServiceMock.Object;
+            }
+
+            private Mock<IMembershipService> membershipServiceMock;
+        }
+    }
+}

--- a/Bonobo.Git.Server.Test/Unit/ControllerTests.RepositoryControllerTests.cs
+++ b/Bonobo.Git.Server.Test/Unit/ControllerTests.RepositoryControllerTests.cs
@@ -1,0 +1,73 @@
+﻿using Bonobo.Git.Server.Controllers;
+using Bonobo.Git.Server.Data;
+using Bonobo.Git.Server.Models;
+using Bonobo.Git.Server.Security;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+
+namespace Bonobo.Git.Server.Test.Unit
+{
+    public partial class ControllerTests
+    {
+        [TestClass]
+        public class RepositoryControllerTests : ControllerTests
+        {
+            [TestInitialize]
+            public void TestInitialize()
+            {
+                sut = new RepositoryController();
+            }
+
+            // get Edit
+            [TestMethod]
+            public void Get_Edit_Executed_With_Empty_Id__Throws_NullReferenceException()
+            {
+                // Arrange
+                try
+                {
+                    // Act
+                    SutAs<RepositoryController>().Edit(Guid.Empty);
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+                // Assert
+                Assert.Fail();
+            }
+
+            // post Edit
+            [TestMethod]
+            public void Post_Edit_Executed_With_Random_id_returns_xx()
+            {
+                // arrange
+                ArrangeUserConfiguration();
+                var guid = Guid.NewGuid();
+
+                var repositoryController = SutAs<RepositoryController>();
+                var repositoryRepositoryMock = SetupMock<IRepositoryRepository>().SetupToReturnAModelWithASpecificIdWhenCallingGetRepositoryMethod(guid);
+                var membershipServiceMock = SetupMock<IMembershipService>().SetupToReturnAnEmptyUserModelListWhenCallingGetAllUsers();                
+                var teamRepositoryMock = SetupMock<ITeamRepository>();
+                teamRepositoryMock.Setup(s => s.GetAllTeams())
+                                  .Returns(new List<TeamModel> { });
+                repositoryController.RepositoryRepository = repositoryRepositoryMock.Object;
+                repositoryController.MembershipService = membershipServiceMock.Object;
+                repositoryController.TeamRepository = teamRepositoryMock.Object;
+
+                //act
+                var result = repositoryController.Edit(guid);
+
+                Assert.IsNotNull(result);
+            }
+
+            // get Create
+            // post Create
+            // get Delete
+            // post Delete
+            // get Clone
+            // post Clone
+        }
+    }
+}

--- a/Bonobo.Git.Server.Test/Unit/ControllerTests.SettingsControllerTests.cs
+++ b/Bonobo.Git.Server.Test/Unit/ControllerTests.SettingsControllerTests.cs
@@ -1,0 +1,141 @@
+﻿using Bonobo.Git.Server.Configuration;
+using Bonobo.Git.Server.Controllers;
+using Bonobo.Git.Server.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Configuration;
+using System.Web;
+using System.Web.Mvc;
+
+namespace Bonobo.Git.Server.Test.Unit
+{
+    public partial class ControllerTests
+    {
+        [TestClass]
+        public class SettingsControllerTests : ControllerTests
+        {
+            [TestInitialize]
+            public void TestInitialize()
+            {
+                sut = new SettingsController();
+                ConfigurationManager.AppSettings["demoModeActive"] = "false";
+                // AuthenticationSettings class controller needs to run again because we changed the demoModelActive appSetting
+                ReinitializeStaticClass(typeof(AuthenticationSettings));
+            }
+
+            [TestMethod]
+            public void Get_Index_Called_With_Uninitialized_Configuration__Throws_TypeInitializationException_Or_DirectoryNotFoundException()
+            {
+                // Arrange
+                ArrangeUserConfiguration();
+
+                // Act
+                var result = SutAs<SettingsController>().Index();
+
+                // Assert
+                Assert.IsNotNull(result);
+            }
+
+            [TestMethod]
+            public void Get_Index_Called_With_Initialized_Configuration__Throws_No_Exceptions()
+            {
+                // Arrange
+                ArrangeUserConfiguration();
+
+                // Act
+                var result = SutAs<SettingsController>().Index();
+
+                // Assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(ViewResult));
+
+                var viewResult = result as ViewResult;
+
+                Assert.IsNotNull(viewResult.Model);
+                Assert.IsInstanceOfType(viewResult.Model, typeof(GlobalSettingsModel));
+            }
+
+            [TestMethod]
+            public void Post_Index_Called_With_Null_Model__Throws_NullReferenceException()
+            {
+                // Arrange
+                ArrangeUserConfiguration();
+
+                try
+                {
+                    // Act
+                    SutAs<SettingsController>().Index(null);
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+
+                // Assert
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Post_Index_Called_With_Unbound_Model__Throws_NullReferenceException()
+            {
+                // Arrange
+                ArrangeUserConfiguration();
+
+                try
+                {
+                    // Act
+                    SutAs<SettingsController>().Index(new GlobalSettingsModel());
+
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+
+                // Assert
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Post_Index_Called_With_Invalid_Model_And_ControllerContext_Set__Returns_ViewResult()
+            {
+                // Arrange
+                ArrangeUserConfiguration();
+                sut.ControllerContext = CreateControllerContext();
+                httpContextMock.SetupGet(hc => hc.Server)
+                               .Returns(new Mock<HttpServerUtilityBase>().Object);
+                GlobalSettingsModel model = new GlobalSettingsModel();
+                BindModelToController(model);
+
+                // Act
+                var result = SutAs<SettingsController>().Index(model);
+
+                // Assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(ViewResult));
+            }
+
+            [TestMethod]
+            public void Post_Index_Called_With_Valid_Model_With_Non_Existent_Folder_And_ControllerContext_Set__Returns_ViewResult_With_Errors()
+            {
+                // Arrange
+                ArrangeUserConfiguration();
+                sut.ControllerContext = CreateControllerContext();
+                httpContextMock.SetupGet(hc => hc.Server)
+                               .Returns(new Mock<HttpServerUtilityBase>().Object);
+                GlobalSettingsModel model = new GlobalSettingsModel { RepositoryPath = "-" };
+                BindModelToController(model);
+
+                // Act
+                var result = SutAs<SettingsController>().Index(model);
+
+                // Assert
+                Assert.IsNotNull(result);
+                Assert.IsInstanceOfType(result, typeof(ViewResult));
+                Assert.IsFalse(sut.ModelState.IsValid);
+                Assert.AreEqual(1, sut.ModelState.Count);
+            }
+        }
+    }
+}

--- a/Bonobo.Git.Server.Test/Unit/ControllerTests.TeamControllerTests.cs
+++ b/Bonobo.Git.Server.Test/Unit/ControllerTests.TeamControllerTests.cs
@@ -1,0 +1,458 @@
+﻿using Bonobo.Git.Server.Controllers;
+using Bonobo.Git.Server.Data;
+using Bonobo.Git.Server.Models;
+using Bonobo.Git.Server.Security;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace Bonobo.Git.Server.Test.Unit
+{
+    public partial class ControllerTests
+    {
+        [TestClass]
+        public class TeamControllerTests : ControllerTests
+        {
+            [TestInitialize]
+            public void TestInitialize()
+            {
+                sut = new TeamController();
+            }
+
+            // get Edit
+            [TestMethod]
+            public void Get_Edit_Executed_Without_ControllerContext_Setup__Throws_NullReferenceException()
+            {
+                // Arrange
+                try
+                {
+                    // Act
+                    SutAs<TeamController>().Edit(Guid.Empty);
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+                // Assert
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Get_Edit_Executed_With_ControllerContext_Setup__Returns_ViewResult_With_Null_Model()
+            {
+                // Arrange
+                sut.ControllerContext = CreateControllerContext();
+                var teamRepositoryMock = SetupMock<ITeamRepository>();
+                var teamController = SutAs<TeamController>();
+                teamController.TeamRepository = teamRepositoryMock.Object;
+
+                // Act
+                var result = teamController.Edit(Guid.Empty);
+
+                // Assert
+                Assert.IsTrue(sut.ModelState.IsValid);
+                var viewResult = AssertAndGetViewResult(result);
+
+                Assert.IsNull(viewResult.Model);
+            }
+
+            [TestMethod]
+            public void Get_Edit_Executed_With_ControllerContext_Setup__Returns_ViewResult_With_Not_Null_Model()
+            {
+                // Arrange
+                sut.ControllerContext = CreateControllerContext();
+                var requestedGuid = Guid.NewGuid();
+                var teamRepositoryMock = SetupMock<ITeamRepository>().SetupToReturnASpecificTeamWhenCallingGetTeamMethod(requestedGuid);
+                var membershipServiceMock = SetupMock<IMembershipService>().SetupToReturnAnEmptyUserModelListWhenCallingGetAllUsers();
+
+                var teamController = SutAs<TeamController>();
+                teamController.TeamRepository = teamRepositoryMock.Object;
+                teamController.MembershipService = membershipServiceMock.Object;
+
+                // Act
+                var result = teamController.Edit(requestedGuid);
+
+                // Assert
+                Assert.IsTrue(sut.ModelState.IsValid);
+                var viewResult = AssertAndGetViewResult(result);
+
+                Assert.IsNotNull(viewResult.Model);
+                Assert.IsInstanceOfType(viewResult.Model, typeof(TeamEditModel));
+
+                var teamEditModel = viewResult.Model as TeamEditModel;
+                Assert.AreEqual(requestedGuid, teamEditModel.Id);
+            }
+
+            // post Edit
+            [TestMethod]
+            public void Post_Edit_Executed_With_Null_Model_And_Without_ControllerContext_Setup__Throws_NullReferenceException()
+            {
+                try
+                {
+                    SutAs<TeamController>().Edit(null);
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Post_Edit_Executed_With_Bare_Model_And_Without_ControllerContext_Setup__Throws_NullReferenceException()
+            {
+                // Arrange
+                try
+                {
+                    // Act
+                    SutAs<TeamController>().Edit(new TeamEditModel());
+
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+                // Assert
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Post_Edit_Executed_With_Null_Model_And_With_ControllerContext_Setup__Throws_NullReferenceException()
+            {
+                sut.ControllerContext = CreateControllerContext();
+
+                try
+                {
+                    SutAs<TeamController>().Edit(null);
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Post_Edit_Executed_With_NonExistent_Model_And_With_ControllerContext_Setup__Returns_ViewResult()
+            {
+                // Arrange
+                sut.ControllerContext = CreateControllerContext();
+                var teamRepositoryMock = SetupMock<ITeamRepository>();
+                var teamController = SutAs<TeamController>();
+                teamController.TeamRepository = teamRepositoryMock.Object;
+
+                var model = new TeamEditModel();
+                BindModelToController(model);
+
+                // Act
+                var result = teamController.Edit(model);
+
+                // Assert
+                var viewResult = AssertAndGetViewResult(result);
+                Assert.IsNull(viewResult.Model);
+            }
+
+            [TestMethod]
+            public void Post_Edit_Executed_With_Existent_Model_And_With_ControllerContext_Setup__Returns_ViewResult_With_Model()
+            {
+                // Arrange
+                sut.ControllerContext = CreateControllerContext();
+                var requestedGuid = Guid.NewGuid();
+                var membershipServiceMock = SetupMock<IMembershipService>().SetupToReturnAnEmptyUserModelListWhenCallingGetAllUsers();
+                var teamRepositoryMock = SetupMock<ITeamRepository>().SetupToReturnASpecificTeamWhenCallingGetTeamMethod(requestedGuid);
+
+                var teamController = SutAs<TeamController>();
+                teamController.TeamRepository = teamRepositoryMock.Object;
+                teamController.MembershipService = membershipServiceMock.Object;
+
+                var model = new TeamEditModel { Id = requestedGuid };
+
+                // Act
+                var result = teamController.Edit(model);
+
+                // Assert
+                var viewResult = AssertAndGetViewResult(result);
+                Assert.IsNotNull(viewResult.Model);
+            }
+
+            // get Create
+            [TestMethod]
+            public void Get_Create_Executed_Without_Arranging_TeamRepository__Throws_NullReferenceException()
+            {
+                // Arrange
+                try
+                {
+                    // Act
+                    SutAs<TeamController>().Create();
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+                // Assert
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Get_Create_Executed_Arranging_MembershipService__Returns_ViewResult()
+            {
+                // Arrange
+                var membershipServiceMock = SetupMock<IMembershipService>().SetupToReturnAnEmptyUserModelListWhenCallingGetAllUsers();
+                var teamController = SutAs<TeamController>();
+                teamController.MembershipService = membershipServiceMock.Object;
+
+                // Act
+                var result = teamController.Create();
+
+                // Assert
+                var viewResult = AssertAndGetViewResult(result);
+                Assert.IsNotNull(viewResult.Model);
+                Assert.IsInstanceOfType(viewResult.Model, typeof(TeamEditModel));
+            }
+
+            // post Create
+            [TestMethod]
+            public void Post_Create_Executed_With_Null_ViewModel__Throws_NullReferenceException()
+            {
+                // Arrange
+                try
+                {
+                    // Act
+                    SutAs<TeamController>().Create(null);
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+                // Assert
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Post_Create_Executed_With_NonNull_ViewModel_Without_Arranging_TeamRepository__Throws_NullReferenceException()
+            {
+                // Arrange
+                try
+                {
+                    // Act
+                    SutAs<TeamController>().Create(new TeamEditModel());
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+                // Assert
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Post_Create_Executed_With_Invalid_ViewModel__Returns_ViewResult_And_Invalid_ModelState()
+            {
+                // Arrange
+                sut.ControllerContext = CreateControllerContext();
+                var teamRepositoryMock = SetupMock<ITeamRepository>();
+                var teamController = SutAs<TeamController>();
+                teamController.TeamRepository = teamRepositoryMock.Object;
+
+                var model = new TeamEditModel();
+                BindModelToController(model);
+
+                // Act
+                var result = teamController.Create(model);
+
+                // Assert
+                Assert.IsFalse(teamController.ModelState.IsValid);
+                var viewResult = AssertAndGetViewResult(result);
+                Assert.IsNotNull(viewResult.Model);
+            }
+
+            [TestMethod]
+            public void Post_Create_Executed_With_Valid_ViewModel_Arranging_TeamRepository__Returns_RedirectToViewResult_With_TempData_Flag_True_And_ModelId()
+            {
+                // Arrange
+                sut.ControllerContext = CreateControllerContext();
+                var teamRepositoryMock = SetupMock<ITeamRepository>().SetupToSucceedWhenCreatingATeam();
+                var teamController = SutAs<TeamController>();
+                teamController.TeamRepository = teamRepositoryMock.Object;
+
+                var model = new TeamEditModel
+                {
+                    Name = "name",
+                    Id = Guid.NewGuid()
+                };
+
+                // Act
+                var result = teamController.Create(model);
+
+                // Assert
+                Assert.AreEqual(true, teamController.TempData["CreateSuccess"]);
+                var redirectToRouteResult = AssertAndGetRedirectToRouteResult(result);
+                Assert.AreEqual(1, redirectToRouteResult.RouteValues.Count);
+                Assert.AreEqual("action", redirectToRouteResult.RouteValues.Keys.First());
+                Assert.AreEqual("Index", redirectToRouteResult.RouteValues["action"]);
+                Assert.AreEqual(2, sut.TempData.Count);
+                Assert.AreEqual(true, sut.TempData["CreateSuccess"]);
+                Assert.AreEqual(model.Id, sut.TempData["NewTeamId"]);
+            }
+
+            // get Delete
+            [TestMethod]
+            public void Get_Delete_Executed_Without_Arranging_TeamRepository_With_Empty_Id__Throws_NullReferenceException()
+            {
+                // Arrange
+                try
+                {
+                    // Act
+                    SutAs<TeamController>().Delete(Guid.Empty);
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+                // Assert
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Get_Delete_Executed_Arranging_TeamRepository_With_No_Setup_For_GetTeam_With_Empty_Id__Returns_Null_Model()
+            {
+                // Arrange
+                sut.ControllerContext = CreateControllerContext();
+                var teamRepositoryMock = SetupMock<ITeamRepository>();
+                var teamController = SutAs<TeamController>();
+                teamController.TeamRepository = teamRepositoryMock.Object;
+
+                // Act
+                var result = teamController.Delete(Guid.Empty);
+
+                // Assert
+                var viewResult = AssertAndGetViewResult(result);
+
+                Assert.IsNull(viewResult.Model);
+            }
+
+            [TestMethod]
+            public void Get_Delete_Executed_Arranging_TeamRepository_With_Setting_Up_GetTeam_With_Valid_Id__Returns_NonNull_Model()
+            {
+                // Arrange
+                sut.ControllerContext = CreateControllerContext();
+                var requestedId = Guid.NewGuid();
+                var teamRepositoryMock = SetupMock<ITeamRepository>().SetupToReturnASpecificTeamWhenCallingGetTeamMethod(requestedId);
+                var membershipServiceMock = SetupMock<IMembershipService>().SetupToReturnAnEmptyUserModelListWhenCallingGetAllUsers();
+
+                var teamController = SutAs<TeamController>();
+                teamController.TeamRepository = teamRepositoryMock.Object;
+                teamController.MembershipService = membershipServiceMock.Object;
+
+                // Act
+                var result = teamController.Delete(requestedId);
+
+                // Assert
+                var viewResult = AssertAndGetViewResult(result);
+                Assert.IsNotNull(viewResult.Model);
+            }
+
+            // post Delete
+            [TestMethod]
+            public void Post_Delete_Executed_Without_Arranging_TeamRepository_With_Null_Model__Returns_RedirectToActionResult_Without_TempData()
+            {
+                // Arrange
+
+                // Act
+                var result = SutAs<TeamController>().Delete(null);
+
+                // Assert
+
+                var redirectToRouteResult = AssertAndGetRedirectToRouteResult(result);
+                Assert.AreEqual(1, redirectToRouteResult.RouteValues.Count);
+                Assert.AreEqual("Index", redirectToRouteResult.RouteValues["action"]);
+
+                Assert.AreEqual(0, sut.TempData.Count);
+            }
+
+            [TestMethod]
+            public void Post_Delete_Executed_Arranging_TeamRepository_With_Valid_Model__Returns_RedirectToActionResult_With_TempData()
+            {
+                // Arrange
+                sut.ControllerContext = CreateControllerContext();
+                var requestedId = Guid.NewGuid();
+                var teamController = SutAs<TeamController>();
+                var teamRepositoryMock = SetupMock<ITeamRepository>().SetupToReturnASpecificTeamWhenCallingGetTeamMethod(requestedId);
+                teamController.TeamRepository = teamRepositoryMock.Object;
+
+                // Act
+                var result = teamController.Delete(new TeamEditModel { Id = requestedId });
+
+                // Assert
+                var redirectToRouteResult = AssertAndGetRedirectToRouteResult(result);
+
+                Assert.AreEqual(1, redirectToRouteResult.RouteValues.Count);
+                Assert.AreEqual("Index", redirectToRouteResult.RouteValues["action"]);
+
+                Assert.AreEqual(1, sut.TempData.Count);
+                Assert.AreEqual("DeleteSuccess", sut.TempData.Keys.FirstOrDefault());
+                Assert.AreEqual(true, sut.TempData["DeleteSuccess"]);
+            }
+
+            // get Detail
+            [TestMethod]
+            public void Get_Detail_Without_Arranging_TeamRepository__Throws_NullReferenceException()
+            {
+                // Arrange
+
+                // Act
+                try
+                {
+                    SutAs<TeamController>().Detail(Guid.Empty);
+                }
+                catch (NullReferenceException)
+                {
+                    return;
+                }
+
+                // Assert
+                Assert.Fail();
+            }
+
+            [TestMethod]
+            public void Get_Detail_Arranging_TeamRepository_With_Unknown_Id__Returns_ViewResult_With_Null_Model()
+            {
+                // Arrange
+                sut.ControllerContext = CreateControllerContext();
+                var teamController = SutAs<TeamController>();
+                var teamRepositoryMock = SetupMock<ITeamRepository>();
+                teamController.TeamRepository = teamRepositoryMock.Object;
+
+                // Act
+                var result = teamController.Detail(Guid.Empty);
+
+                // Assert
+                var viewResult = AssertAndGetViewResult(result);
+                Assert.IsNull(viewResult.Model);
+            }
+
+            [TestMethod]
+            public void Get_Detail_Arranging_TeamRepository_With_Known_Id__Returns_ViewResult_With_Null_Model()
+            {
+                // Arrange
+                sut.ControllerContext = CreateControllerContext();
+                var requestedId = Guid.NewGuid();
+                var teamController = SutAs<TeamController>();
+                var teamRepositoryMock = SetupMock<ITeamRepository>().SetupToReturnASpecificTeamWhenCallingGetTeamMethod(requestedId);
+                var membershipServiceMock = SetupMock<IMembershipService>();
+                var repositoryRepositoryMock = SetupMock<IRepositoryRepository>().SetupToReturnAnEmptyListForASpecificIdWhenCallingGetTeamRepositories(requestedId);
+
+                teamController.TeamRepository = teamRepositoryMock.Object;
+                teamController.MembershipService = membershipServiceMock.Object;
+                teamController.RepositoryRepository = repositoryRepositoryMock.Object;
+
+                // Act
+                var result = teamController.Detail(requestedId);
+
+                // Assert
+                var viewResult = AssertAndGetViewResult(result);
+                Assert.IsNotNull(viewResult.Model);
+            }
+        }
+    }
+}

--- a/Bonobo.Git.Server.Test/Unit/ControllerTests.cs
+++ b/Bonobo.Git.Server.Test/Unit/ControllerTests.cs
@@ -1,0 +1,141 @@
+﻿using Bonobo.Git.Server.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Web;
+using System.Web.Mvc;
+
+namespace Bonobo.Git.Server.Test.Unit
+{
+    public partial class ControllerTests
+    {
+        private T SutAs<T>() where T : Controller => sut as T;
+
+        private Mock<T> SetupMock<T>() where T : class
+        {
+            return new Mock<T>();
+        }
+
+        private void SetupUserAsAdmin()
+        {
+            claimsPrincipalMock.Setup(p => p.IsInRole(Definitions.Roles.Administrator))
+                               .Returns(true);
+        }
+
+
+        private void SetHttpContextMockIntoSUT(Guid id)
+        {
+            var claimsIdentity = new ClaimsIdentity(new List<Claim> { new Claim(ClaimTypes.NameIdentifier, id.ToString()) });
+
+            IPrincipal user = CreateClaimsPrincipalFromClaimsIdentity(claimsIdentity);
+
+            sut.ControllerContext = CreateControllerContextFromPrincipal(user);
+        }
+
+        private IPrincipal CreateClaimsPrincipalFromClaimsIdentity(ClaimsIdentity claimsIdentity)
+        {
+            // see: https://stackoverflow.com/a/1784417/41236
+            claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+            claimsPrincipalMock.SetupGet(p => p.Identities)
+                               .Returns(new List<ClaimsIdentity> { claimsIdentity });
+
+            // see: https://stackoverflow.com/a/1783704/41236
+            IPrincipal user = claimsPrincipalMock.Object;
+            return user;
+        }
+
+        private void BindModelToController<T>(T model)
+        {
+            // see: https://stackoverflow.com/a/5580363/41236
+            var modelBinder = new ModelBindingContext
+            {
+                ModelMetadata = ModelMetadataProviders.Current.GetMetadataForType(() => model, typeof(T)),
+                ValueProvider = new NameValueCollectionValueProvider(new NameValueCollection(), CultureInfo.InvariantCulture)
+            };
+            var binder = new DefaultModelBinder().BindModel(new ControllerContext(), modelBinder);
+            sut.ModelState.Clear();
+            sut.ModelState.Merge(modelBinder.ModelState);
+        }
+
+        private ControllerContext CreateControllerContext()
+        {
+            return CreateControllerContextFromPrincipal(new Mock<IPrincipal>().Object);
+        }
+
+        protected ControllerContext CreateControllerContextFromPrincipal(IPrincipal user)
+        {
+            httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.SetupGet(ctx => ctx.User).Returns(user);
+
+            responseMock = new Mock<HttpResponseBase>();
+            httpContextMock.SetupGet(c => c.Response)
+                           .Returns(responseMock.Object);
+
+            var controllerCtx = new ControllerContext
+            {
+                HttpContext = httpContextMock.Object
+            };
+            return controllerCtx;
+        }
+
+        private static ViewResult AssertAndGetViewResult(ActionResult result)
+        {
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(ViewResult));
+
+            return result as ViewResult;
+        }
+
+        private static RedirectToRouteResult AssertAndGetRedirectToRouteResult(ActionResult result)
+        {
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(RedirectToRouteResult));
+
+            return result as RedirectToRouteResult;
+        }
+
+        private static void AssertRedirectToHomeUnauthorized(ActionResult result)
+        {
+            RedirectToRouteResult redirectToRouteResult = AssertAndGetRedirectToRouteResult(result);
+
+            Assert.IsNotNull(redirectToRouteResult);
+            Assert.AreEqual("Home", redirectToRouteResult.RouteValues["controller"]);
+            Assert.AreEqual("Unauthorized", redirectToRouteResult.RouteValues["action"]);
+        }
+
+        private void SetupCookiesCollectionToHttpResponse()
+        {
+            HttpCookieCollection cookies = new HttpCookieCollection();
+            responseMock.SetupGet(r => r.Cookies)
+                        .Returns(cookies);
+        }
+
+        private static void ArrangeUserConfiguration()
+        {
+            Mock<IPathResolver> pathResolverMock = new Mock<IPathResolver>();
+            pathResolverMock.Setup(p => p.Resolve(It.IsAny<string>()))
+                            .Returns(".");
+            pathResolverMock.Setup(p => p.ResolveWithConfiguration(It.IsAny<string>()))
+                            .Returns("test.config");
+            UserConfiguration.PathResolver = pathResolverMock.Object;
+        }
+
+        private static void ReinitializeStaticClass(Type type)
+        {
+            // This code allows reinitializing a static class 
+            // see: https://stackoverflow.com/a/51758748/41236
+            //
+            type.TypeInitializer.Invoke(null, null);
+        }
+
+        private Controller sut;
+        private Mock<ClaimsPrincipal> claimsPrincipalMock;
+        private Mock<HttpContextBase> httpContextMock;
+        private Mock<HttpResponseBase> responseMock;
+    }
+}

--- a/Bonobo.Git.Server.Test/packages.config
+++ b/Bonobo.Git.Server.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.4.0" targetFramework="net46" />
+  <package id="Castle.Core" version="4.4.1" targetFramework="net46" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net46" />
   <package id="Microsoft.AspNet.Mvc.Futures" version="5.0.0" targetFramework="net451" />

--- a/Bonobo.Git.Server.sln
+++ b/Bonobo.Git.Server.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31025.194
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bonobo.Git.Server", "Bonobo.Git.Server\Bonobo.Git.Server.csproj", "{6129B3FE-B282-4F6F-8836-8AF66602F8DA}"
 EndProject


### PR DESCRIPTION
Hi @willdean, this PR (fixing failed #883) contains a set of tests for Controllers that don't modify any server code, just adds test code.
All Tests pass

I started this time from master with all commits squashed as we discussed before.
